### PR TITLE
Add support for external connections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,14 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"type": "lldb",
+			"request": "launch",
+			"name": "Run QueryScript",
+			"program": "${workspaceFolder}/target/debug/qs",
+			"args": ["${input:qsfile}"],
+			"cwd": "${workspaceFolder}",
+		},
+		{
 			"type": "extensionHost",
 			"request": "launch",
 			"name": "Launch VSCode Extension",
@@ -39,5 +47,18 @@
 				"SERVER_PATH": "${workspaceRoot}/target/debug/queryscript-lsp"
 			},
 		}
-	]
+	],
+	"inputs": [
+		{
+            "id": "qsfile",
+            "type": "command",
+            "command": "memento.promptString",
+            "args": {
+                "id": "qsfile",
+                "description": "Path to the QS file to run (relative to queryscript root)",
+                "placeholder": "File path"
+            }
+        }
+	  ]
+
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,6 +1800,7 @@ dependencies = [
  "tokio",
  "ts-rs",
  "unicase",
+ "url",
  "walkdir",
 ]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -211,7 +211,7 @@ fn run_file(
         return Ok(());
     }
 
-    let ctx = queryscript::runtime::Context::new(&schema, engine_type);
+    let ctx = queryscript::runtime::Context::new(schema.read()?.folder.clone(), engine_type);
     let locked_schema = schema.read()?;
     for expr in locked_schema.exprs.iter() {
         let expr = expr.to_runtime_type().context(RuntimeSnafu {

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -160,17 +160,20 @@ fn run_command(
                 .compile_schema_ast(repl_schema.clone(), &ast)
                 .as_result()?;
 
-            let compiled = {
+            let (compiled, folder) = {
                 let locked_schema = repl_schema.read()?;
-                if locked_schema.exprs.len() > num_exprs {
-                    Some(locked_schema.exprs.last().unwrap().clone())
-                } else {
-                    None
-                }
+                (
+                    if locked_schema.exprs.len() > num_exprs {
+                        Some(locked_schema.exprs.last().unwrap().clone())
+                    } else {
+                        None
+                    },
+                    locked_schema.folder.clone(),
+                )
             };
 
             if let Some(compiled) = compiled {
-                let ctx = queryscript::runtime::Context::new(&repl_schema, engine_type);
+                let ctx = queryscript::runtime::Context::new(folder, engine_type);
                 let expr = compiled.to_runtime_type().context(RuntimeSnafu {
                     file: file.to_string(),
                 })?;

--- a/lsp/src/lsp.rs
+++ b/lsp/src/lsp.rs
@@ -651,7 +651,9 @@ fn get_runnable_expr_from_decl(
 fn find_expr_by_location(
     schema: &Schema,
     loc: &queryscript::ast::Location,
-) -> Result<Option<queryscript::compile::schema::TypedExpr<queryscript::compile::schema::Ref<QSType>>>> {
+) -> Result<
+    Option<queryscript::compile::schema::TypedExpr<queryscript::compile::schema::Ref<QSType>>>,
+> {
     if let Some(expr) = schema.exprs.iter().find(|expr| {
         let expr_loc = expr.location();
         expr_loc.contains(loc)
@@ -1014,7 +1016,14 @@ impl Backend {
             }
         };
 
-        let ctx = runtime::Context::new(&schema_ref, runtime::SQLEngineType::DuckDB);
+        let ctx = runtime::Context::new(
+            schema_ref
+                .read()
+                .map_err(log_internal_error)?
+                .folder
+                .clone(),
+            runtime::SQLEngineType::DuckDB,
+        );
 
         // XXX We should change this log_internal_error to return an error to the webview
         let value = runtime::eval(&ctx, &expr)

--- a/queryscript/Cargo.toml
+++ b/queryscript/Cargo.toml
@@ -35,6 +35,7 @@ tabled = "0.10"
 tokio = "1.23"
 ts-rs = { version = "6.2", optional = true }
 unicase = "2.6.0"
+url = "2.3.1"
 
 # We don't import this directly (rather, through "arrow"), but need the serde feature
 # to be propagated through to it.

--- a/queryscript/src/compile/autocomplete.rs
+++ b/queryscript/src/compile/autocomplete.rs
@@ -123,12 +123,18 @@ fn get_imported_decls<E: schema::Entry>(
     schema: schema::Ref<schema::Schema>,
     path: &Vec<ast::Located<ast::Ident>>,
 ) -> Result<Vec<ast::Ident>> {
-    let (schema, _, remainder) =
-        compile::lookup_path::<E>(compiler, schema.clone(), path, true, true)?;
+    let (schema, _, remainder) = compile::lookup_path::<E>(
+        compiler,
+        schema::Importer::Schema(schema.clone()),
+        path,
+        true,
+        true,
+    )?;
     if remainder.len() > 0 {
         return Ok(Vec::new());
     }
     return Ok(schema
+        .as_schema()?
         .read()?
         .get_decls::<E>()
         .keys()
@@ -278,7 +284,7 @@ impl AutoCompleter {
             .map_or(Vec::new(), |path| {
                 let mut choices = Vec::new();
 
-                if let Ok(c) = get_imported_decls::<schema::SchemaEntry>(
+                if let Ok(c) = get_imported_decls::<schema::SchemaPath>(
                     self.compiler.clone(),
                     self.schema.clone(),
                     &path,

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -539,7 +539,7 @@ pub fn lookup_schema(
     } else {
         let imported = match &path {
             SchemaPath::Schema(path) => {
-                let (k, v) = if let Some(root) = &schema.read()?.folder {
+                let v = if let Some(root) = &schema.read()?.folder {
                     let mut file_path_buf = FilePath::new(root).to_path_buf();
                     for p in path {
                         file_path_buf.push(FilePath::new(p.get()));
@@ -556,7 +556,7 @@ pub fn lookup_schema(
                         .0
                         .as_result()?
                         .unwrap();
-                    (path.clone(), s.clone())
+                    s.clone()
                 } else {
                     return Err(CompileError::no_such_entry(path.clone()));
                 };

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -862,10 +862,13 @@ fn compile_expr(compiler: Compiler, schema: Ref<Schema>, expr: &ast::Expr) -> Re
                     type_,
                     expr: compiler.async_cref(async move {
                         let query = cunwrap(query.await?)?;
-                        Ok(mkcref(Expr::SQL(Arc::new(SQL {
-                            names: query.names,
-                            body: SQLBody::Query(query.body),
-                        }))))
+                        Ok(mkcref(Expr::SQL(
+                            Arc::new(SQL {
+                                names: query.names,
+                                body: SQLBody::Query(query.body),
+                            }),
+                            None,
+                        )))
                     })?,
                 })
             }

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -862,13 +862,10 @@ fn compile_expr(compiler: Compiler, schema: Ref<Schema>, expr: &ast::Expr) -> Re
                     type_,
                     expr: compiler.async_cref(async move {
                         let query = cunwrap(query.await?)?;
-                        Ok(mkcref(Expr::SQL(
-                            Arc::new(SQL {
-                                names: query.names,
-                                body: SQLBody::Query(query.body),
-                            }),
-                            None,
-                        )))
+                        Ok(mkcref(Expr::native_sql(Arc::new(SQL {
+                            names: query.names,
+                            body: SQLBody::Query(query.body),
+                        }))))
                     })?,
                 })
             }

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -619,7 +619,9 @@ pub fn lookup_path<E: Entry>(
     for (i, ident) in path.iter().enumerate() {
         let check_visibility = i > 0;
 
-        if let Some(decl) = imported_object.get_and_check::<E>(&ident, check_visibility, path)? {
+        if let Some(decl) =
+            imported_object.get_and_check::<E>(&compiler, &ident, check_visibility, path)?
+        {
             return Ok((
                 imported_object,
                 Some(decl.get().clone()),
@@ -635,9 +637,12 @@ pub fn lookup_path<E: Entry>(
             }
         };
 
-        let new = if let Some(imported) =
-            imported_object.get_and_check::<SchemaPath>(&ident, check_visibility, path)?
-        {
+        let new = if let Some(imported) = imported_object.get_and_check::<SchemaPath>(
+            &compiler,
+            &ident,
+            check_visibility,
+            path,
+        )? {
             lookup_schema(compiler.clone(), schema.clone(), &imported.value)?
                 .read()?
                 .schema

--- a/queryscript/src/compile/connection.rs
+++ b/queryscript/src/compile/connection.rs
@@ -1,0 +1,104 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use url::Url;
+
+use crate::ast::{Ident, Located};
+
+use super::{
+    error::{ErrorLocation, Result},
+    CompileError,
+};
+
+pub struct ConnectionString(Located<Url>);
+
+impl ConnectionString {
+    pub fn maybe_parse(
+        folder: Option<String>,
+        p: &str,
+        loc: &ErrorLocation,
+    ) -> Result<Option<Arc<ConnectionString>>> {
+        let mut url = match Url::parse(p) {
+            Ok(url) => url,
+            Err(_) => return Ok(None),
+        };
+
+        match url.scheme() {
+            "file" => {
+                // NOTE: Eventually file URLs can allow you to reference schemas located
+                // elsewhere on the filesystem.
+                return Err(CompileError::unimplemented(
+                    loc.clone(),
+                    "file:// URLs are not supported. Use a relative path instead.",
+                ));
+            }
+            "duckdb" => {}
+            other => {
+                return Err(CompileError::unimplemented(
+                    loc.clone(),
+                    &format!("{} URLs", other),
+                ));
+            }
+        };
+
+        if matches!(url.scheme(), "duckdb") && matches!(url.host_str(), Some(_)) {
+            // Allow relative paths for schemes that are on the filesystem
+
+            let host_str = url.host_str().unwrap();
+            let mut new_path = PathBuf::new();
+            if let Some(folder) = folder {
+                new_path.push(folder);
+            }
+            new_path.push(host_str);
+            new_path = new_path.join(url.path().trim_start_matches('/'));
+
+            url.set_host(None).unwrap();
+            url.set_path(new_path.to_str().unwrap());
+        }
+
+        let mut valid_db_name = false;
+        if let Some(segments) = url.path_segments() {
+            valid_db_name = segments.count() > 0;
+        }
+        if !valid_db_name {
+            return Err(CompileError::invalid_conn(
+                loc.clone(),
+                "missing a database name",
+            ));
+        }
+
+        Ok(Some(Arc::new(ConnectionString(Located::new(
+            url,
+            loc.clone(),
+        )))))
+    }
+
+    pub fn db_name(&self) -> Located<Ident> {
+        let path = Path::new(self.0.path());
+        Located::new(
+            path.file_stem().unwrap().to_str().unwrap().into(),
+            self.0.location().clone(),
+        )
+    }
+}
+
+impl std::fmt::Debug for ConnectionString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ConnectionString(")?;
+        write!(f, "{:?}://", self.0.scheme())?;
+        match self.0.host() {
+            Some(h) => write!(f, "{}", h)?,
+            None => {}
+        };
+        write!(f, "{:?}", self.0.path())?;
+        write!(f, ")")
+    }
+}
+
+fn connection_infer_fn() -> impl std::future::Future<Output = Result<()>> + Send + 'static {
+    async move {
+        return Err(CompileError::unimplemented(
+            ErrorLocation::Unknown,
+            "connection inference",
+        ));
+    }
+}

--- a/queryscript/src/compile/error.rs
+++ b/queryscript/src/compile/error.rs
@@ -122,6 +122,13 @@ pub enum CompileError {
         loc: ErrorLocation,
     },
 
+    #[snafu(display("Invalid connection: {}", what))]
+    InvalidConnectionError {
+        what: String,
+        backtrace: Option<Backtrace>,
+        loc: ErrorLocation,
+    },
+
     #[snafu(display("{}", sources.first().unwrap()))]
     Multiple {
         // This is assumed to be non-empty
@@ -183,6 +190,14 @@ impl CompileError {
 
     pub fn scalar_subselect(loc: ErrorLocation, what: &str) -> CompileError {
         return ScalarSubselectSnafu {
+            loc,
+            what: what.to_string(),
+        }
+        .build();
+    }
+
+    pub fn invalid_conn(loc: ErrorLocation, what: &str) -> CompileError {
+        return InvalidConnectionSnafu {
             loc,
             what: what.to_string(),
         }
@@ -259,6 +274,7 @@ impl PrettyError for CompileError {
             CompileError::CoercionError { loc, .. } => loc.clone(),
             CompileError::ImportError { path, .. } => path_location(path),
             CompileError::ScalarSubselectError { loc, .. } => loc.clone(),
+            CompileError::InvalidConnectionError { loc, .. } => loc.clone(),
             CompileError::Multiple { sources } => sources.first().unwrap().location(),
         }
     }

--- a/queryscript/src/compile/external.rs
+++ b/queryscript/src/compile/external.rs
@@ -8,7 +8,7 @@ use super::{
     error::{Result, RuntimeSnafu},
     inference::mkcref,
     schema::{CRef, CTypedExpr, Expr, MType},
-    CompileError, SchemaRef,
+    CompileError,
 };
 
 // XXX If a record has two fields with the same name, we should throw an error. Eventually,

--- a/queryscript/src/compile/external.rs
+++ b/queryscript/src/compile/external.rs
@@ -1,0 +1,71 @@
+use crate::{
+    ast::{Ident, Located, SourceLocation},
+    types::{AtomicType, Type},
+};
+use snafu::prelude::*;
+
+use super::{
+    error::{Result, RuntimeSnafu},
+    inference::mkcref,
+    schema::{CRef, CTypedExpr, Expr, MType},
+    CompileError, SchemaRef,
+};
+
+// XXX If a record has two fields with the same name, we should throw an error. Eventually,
+// we should support this, because SQL engines do.
+fn validate_inferred_type(type_: &Type) -> Result<()> {
+    match type_ {
+        Type::Atom(..) => {}
+        Type::Fn(..) => {}
+        Type::List(inner) => validate_inferred_type(inner)?,
+        Type::Record(fields) => {
+            let mut seen = std::collections::HashSet::new();
+            for field in fields {
+                if seen.contains(&field.name) {
+                    return Err(CompileError::duplicate_entry(vec![
+                        Ident::without_location(field.name.clone()),
+                    ]));
+                }
+                seen.insert(field.name.clone());
+                validate_inferred_type(&field.type_)?;
+            }
+        }
+    };
+    Ok(())
+}
+
+pub fn schema_infer_expr_fn(
+    folder: Option<String>,
+    expr: CRef<Expr<CRef<MType>>>,
+    inner_type: CRef<MType>,
+) -> impl std::future::Future<Output = Result<()>> + Send + 'static {
+    async move {
+        let ctx = crate::runtime::Context::new(folder, crate::runtime::SQLEngineType::DuckDB)
+            .disable_typechecks();
+
+        let typed_expr = CTypedExpr {
+            expr: expr.clone(),
+            type_: mkcref(MType::Atom(Located::new(
+                AtomicType::Null,
+                SourceLocation::Unknown,
+            ))),
+        }
+        .to_runtime_type()
+        .context(RuntimeSnafu {
+            loc: SourceLocation::Unknown,
+        })?;
+
+        let result = crate::runtime::eval(&ctx, &typed_expr)
+            .await
+            .context(RuntimeSnafu {
+                loc: SourceLocation::Unknown,
+            })?;
+
+        let inferred_type = result.type_();
+        validate_inferred_type(&inferred_type)?;
+        let inferred_mtype = mkcref(MType::from_runtime_type(&inferred_type)?);
+
+        inner_type.unify(&inferred_mtype)?;
+        Ok(())
+    }
+}

--- a/queryscript/src/compile/inline.rs
+++ b/queryscript/src/compile/inline.rs
@@ -75,7 +75,14 @@ impl SQLVisitor for ParamInliner {
                 }
 
                 if let Some(e) = self.context.get(&name.0[0].get().into()) {
-                    Some(e.as_table(alias.clone()))
+                    let new_alias = match alias {
+                        Some(alias) => alias.clone(),
+                        None => sqlast::TableAlias {
+                            name: name.0[0].clone(),
+                            columns: vec![],
+                        },
+                    };
+                    Some(e.as_table(Some(new_alias)))
                 } else {
                     None
                 }

--- a/queryscript/src/compile/mod.rs
+++ b/queryscript/src/compile/mod.rs
@@ -17,6 +17,7 @@ mod util;
 pub use compile::{
     lookup_path, lookup_schema, Compiler, CompilerConfig, OnSchema, OnSymbol, SymbolKind,
 };
+pub use connection::ConnectionString;
 pub use error::{CompileError, Result};
 pub use schema::{mkref, Schema, SchemaRef};
 pub use sql::compile_reference;

--- a/queryscript/src/compile/mod.rs
+++ b/queryscript/src/compile/mod.rs
@@ -2,6 +2,7 @@ pub mod autocomplete;
 mod builtin_types;
 mod coerce;
 pub mod compile;
+mod connection;
 pub mod error;
 mod generics;
 pub mod inference;

--- a/queryscript/src/compile/mod.rs
+++ b/queryscript/src/compile/mod.rs
@@ -4,6 +4,7 @@ mod coerce;
 pub mod compile;
 mod connection;
 pub mod error;
+mod external;
 mod generics;
 pub mod inference;
 pub mod inline;

--- a/queryscript/src/compile/schema.rs
+++ b/queryscript/src/compile/schema.rs
@@ -862,15 +862,11 @@ impl Expr<CRef<MType>> {
         }
     }
 
-    pub async fn unwrap_schema_entry(
-        self: &Arc<Expr<CRef<MType>>>,
-    ) -> Result<Arc<Expr<CRef<MType>>>> {
+    pub async fn unwrap_schema_entry(self: &Expr<CRef<MType>>) -> Result<Expr<CRef<MType>>> {
         let mut ret = self.clone();
         loop {
-            match ret.as_ref() {
-                Expr::SchemaEntry(STypedExpr { expr, .. }) => {
-                    ret = Arc::new(expr.await?.read()?.clone())
-                }
+            match ret {
+                Expr::SchemaEntry(STypedExpr { expr, .. }) => ret = expr.await?.read()?.clone(),
                 _ => return Ok(ret),
             }
         }

--- a/queryscript/src/compile/schema.rs
+++ b/queryscript/src/compile/schema.rs
@@ -59,7 +59,6 @@ pub enum MType {
     Fn(Located<MFnType>),
     Name(Located<Ident>),
     Generic(Located<Arc<dyn Generic>>),
-    Connection(Located<()>),
 }
 
 impl MType {
@@ -101,9 +100,6 @@ impl MType {
             })),
             MType::Name { .. } => {
                 runtime::error::fail!("Unresolved type name cannot exist at runtime: {:?}", self)
-            }
-            MType::Connection(..) => {
-                runtime::error::fail!("Unresolved connection cannot exist at runtime: {:?}", self)
             }
             MType::Generic(generic) => generic.to_runtime_type(),
         }
@@ -202,7 +198,6 @@ impl MType {
                     location.clone(),
                 )))
             }
-            MType::Connection(loc) => mkcref(MType::Connection(loc.clone())),
         };
 
         Ok(type_)
@@ -216,7 +211,6 @@ impl MType {
             MType::Fn(t) => t.location().clone(),
             MType::Name(t) => t.location().clone(),
             MType::Generic(t) => t.location().clone(),
-            MType::Connection(loc) => loc.location().clone(),
         }
     }
 }
@@ -328,7 +322,6 @@ impl fmt::Debug for MType {
             MType::Generic(t) => {
                 t.get().fmt(f)?;
             }
-            MType::Connection(_) => f.write_str("connection")?,
         }
         Ok(())
     }
@@ -382,12 +375,6 @@ impl Constrainable for MType {
                 return Err(CompileError::internal(
                     name.location().clone(),
                     format!("Encountered free type variable: {}", name.get()).as_str(),
-                ))
-            }
-            MType::Connection(loc) => {
-                return Err(CompileError::internal(
-                    loc.location().clone(),
-                    "Encountered connection",
                 ))
             }
             MType::Generic(generic) => {

--- a/queryscript/src/compile/schema.rs
+++ b/queryscript/src/compile/schema.rs
@@ -13,6 +13,7 @@ use crate::ast::SourceLocation;
 use crate::compile::{
     coerce::{coerce_types, CoerceOp},
     compile::SymbolKind,
+    connection::ConnectionString,
     error::*,
     generics::Generic,
     inference::{mkcref, Constrainable, Constrained},
@@ -814,6 +815,10 @@ where
     FnCall(FnCallExpr<TypeRef>),
     NativeFn(Ident),
     ContextRef(Ident),
+
+    /// A name (e.g. a table or view) in a database connection.
+    ConnectionObject(Arc<ConnectionString>, Ident),
+
     Unknown,
 }
 
@@ -853,6 +858,9 @@ impl Expr<CRef<MType>> {
             Expr::SchemaEntry(e) => Ok(Expr::SchemaEntry(e.clone())),
             Expr::NativeFn(f) => Ok(Expr::NativeFn(f.clone())),
             Expr::ContextRef(r) => Ok(Expr::ContextRef(r.clone())),
+            Expr::ConnectionObject(url, name) => {
+                Ok(Expr::ConnectionObject(url.clone(), name.clone()))
+            }
             Expr::Unknown => Ok(Expr::Unknown),
         }
     }

--- a/queryscript/src/compile/schema.rs
+++ b/queryscript/src/compile/schema.rs
@@ -1,8 +1,9 @@
-use crate::ast::Pretty;
+use crate::ast::{Pretty, ToIdents};
 pub use arrow::datatypes::DataType as ArrowDataType;
 use colored::*;
 use snafu::prelude::*;
 use sqlparser::ast::{self as sqlast, WildcardAdditionalOptions};
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Debug};
 use std::sync::{Arc, RwLock};
@@ -13,7 +14,7 @@ use crate::ast::SourceLocation;
 use crate::compile::{
     coerce::{coerce_types, CoerceOp},
     compile::SymbolKind,
-    connection::ConnectionString,
+    connection::{ConnectionSchema, ConnectionString},
     error::*,
     generics::Generic,
     inference::{mkcref, Constrainable, Constrained},
@@ -953,21 +954,72 @@ pub fn mkref<T>(t: T) -> Ref<T> {
     Arc::new(RwLock::new(t))
 }
 
-pub trait Entry: Clone {
-    fn run_on_info(&self) -> Option<(SymbolKind, CRef<SType>)>;
-    fn get_map(schema: &Schema) -> &DeclMap<Self>;
-    fn kind() -> &'static str;
+#[derive(Clone, Debug)]
+pub enum SchemaPath {
+    Schema(ast::Path),
+    Connection(Arc<ConnectionString>),
 }
 
-pub type SchemaEntry = ast::Path;
+// Implement PartialEq, etc. so that we strip the locations away before doing comparisons
+impl PartialEq for SchemaPath {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (SchemaPath::Schema(p1), SchemaPath::Schema(p2)) => p1.to_idents() == p2.to_idents(),
+            (SchemaPath::Connection(c1), SchemaPath::Connection(c2)) => {
+                c1.get_url() == c2.get_url()
+            }
+            _ => false,
+        }
+    }
+}
+impl Eq for SchemaPath {}
+
+impl PartialOrd for SchemaPath {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (SchemaPath::Schema(p1), SchemaPath::Schema(p2)) => {
+                p1.to_idents().partial_cmp(&p2.to_idents())
+            }
+            (SchemaPath::Connection(c1), SchemaPath::Connection(c2)) => {
+                c1.get_url().partial_cmp(c2.get_url())
+            }
+            (SchemaPath::Connection(..), SchemaPath::Schema(..)) => Some(Ordering::Less),
+            (SchemaPath::Schema(..), SchemaPath::Connection(..)) => Some(Ordering::Greater),
+        }
+    }
+}
+
+impl Ord for SchemaPath {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+pub trait Entry: Clone {
+    fn kind() -> &'static str;
+    fn run_on_info(&self) -> Option<(SymbolKind, CRef<SType>)>;
+
+    // XXX if convert this to get_entry() or something like that, we won't need
+    // two separate implementations?
+    fn get_map(schema: &Schema) -> &DeclMap<Self>;
+    fn get_conn_decl(
+        url: &mut ConnectionSchema,
+        ident: &Located<Ident>,
+        check_visibility: bool,
+        full_path: &ast::Path,
+    ) -> Result<Option<Located<Decl<Self>>>> {
+        Ok(None)
+    }
+}
+
 pub type TypeEntry = CRef<MType>;
 pub type ExprEntry = STypedExpr;
 
-impl Entry for SchemaEntry {
+impl Entry for SchemaPath {
     fn run_on_info(&self) -> Option<(SymbolKind, CRef<SType>)> {
         None
     }
-    fn get_map(schema: &Schema) -> &DeclMap<SchemaEntry> {
+    fn get_map(schema: &Schema) -> &DeclMap<SchemaPath> {
         &schema.schema_decls
     }
     fn kind() -> &'static str {
@@ -994,6 +1046,14 @@ impl Entry for ExprEntry {
     }
     fn kind() -> &'static str {
         "type"
+    }
+    fn get_conn_decl(
+        schema: &mut ConnectionSchema,
+        ident: &Located<Ident>,
+        check_visibility: bool,
+        full_path: &ast::Path,
+    ) -> Result<Option<Located<Decl<Self>>>> {
+        schema.get_decl(ident, check_visibility, full_path)
     }
 }
 
@@ -1038,10 +1098,56 @@ pub struct TypedName<TypeRef> {
     pub type_: TypeRef,
 }
 
+// We could potentially make this a trait instead, and make lookup_path generic on it. However, that
+// makes it hard to dynamically return an Importer (we'd have to return an Arc<dyn Importer>), which
+// doesn't seem worth it.
+#[derive(Clone, Debug)]
+pub enum Importer {
+    Schema(SchemaRef),
+    Connection(Ref<ConnectionSchema>),
+}
+
+impl Importer {
+    // XXX We may want to have a different SourceLocation option here.
+    pub fn location(&self) -> Result<SourceLocation> {
+        Ok(match &self {
+            Importer::Schema(schema) => SourceLocation::File(schema.read()?.file.clone()),
+            Importer::Connection(url) => SourceLocation::File(format!("{:?}", url)),
+        })
+    }
+
+    pub fn get_and_check<E: Entry>(
+        &self,
+        ident: &Located<Ident>,
+        check_visibility: bool,
+        full_path: &ast::Path,
+    ) -> Result<Option<Located<Decl<E>>>> {
+        Ok(match &self {
+            Importer::Schema(schema) => schema
+                .read()?
+                .get_and_check(ident, check_visibility, full_path)?
+                .cloned(),
+            Importer::Connection(schema) => {
+                E::get_conn_decl(&mut *schema.write()?, ident, check_visibility, full_path)?
+            }
+        })
+    }
+
+    pub fn as_schema(&self) -> Result<SchemaRef> {
+        match &self {
+            Importer::Schema(schema) => Ok(schema.clone()),
+            Importer::Connection(..) => Err(CompileError::internal(
+                SourceLocation::Unknown,
+                "Connection, not a schema",
+            )),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ImportedSchema {
     pub args: Option<Vec<BTreeMap<String, TypedNameAndExpr<CRef<MType>>>>>,
-    pub schema: SchemaRef,
+    pub schema: Importer,
 }
 
 impl<T> Pretty for Located<T> {
@@ -1059,11 +1165,11 @@ pub struct Schema {
     pub parent_scope: Option<Ref<Schema>>,
     pub externs: BTreeMap<Ident, CRef<MType>>,
 
-    pub schema_decls: DeclMap<ast::Path>,
+    pub schema_decls: DeclMap<SchemaPath>,
     pub type_decls: DeclMap<CRef<MType>>,
     pub expr_decls: DeclMap<STypedExpr>,
 
-    pub imports: BTreeMap<Vec<Ident>, Ref<ImportedSchema>>,
+    pub imports: BTreeMap<SchemaPath, Ref<ImportedSchema>>,
     pub exprs: Vec<Located<CTypedExpr>>,
 }
 

--- a/queryscript/src/compile/sql.rs
+++ b/queryscript/src/compile/sql.rs
@@ -290,7 +290,7 @@ pub fn compile_reference(
 ) -> Result<TypedExpr<CRef<MType>>> {
     let (_, decl, remainder) = lookup_path::<ExprEntry>(
         compiler.clone(),
-        schema.clone(),
+        Importer::Schema(schema.clone()),
         &path,
         true, /* import_global */
         true, /* resolve_last */

--- a/queryscript/src/compile/sql.rs
+++ b/queryscript/src/compile/sql.rs
@@ -2340,7 +2340,7 @@ pub fn compile_sqlexpr(
 
                     let func_expr = func.expr.unwrap_schema_entry().await?;
 
-                    let (fn_kind, fn_body) = match func_expr.as_ref() {
+                    let (fn_kind, fn_body) = match &func_expr {
                         Expr::NativeFn(_) => (FnKind::Native, None),
                         Expr::Fn(FnExpr { body, .. }) => match body {
                             FnBody::SQLBuiltin => (FnKind::SQLBuiltin, None),
@@ -2406,9 +2406,9 @@ pub fn compile_sqlexpr(
                                 // the SQL of the function body.  This should result in a version
                                 // of the body with all SQL arguments fully inlined.
                                 //
-                                let fn_body = inline_params(fn_body).await?;
+                                let fn_body = inline_params(fn_body.as_ref()).await?;
 
-                                Ok(mkcref(fn_body.as_ref().clone()))
+                                Ok(mkcref(fn_body))
                             }
                             // Otherwise, create a SQL function call.
                             //

--- a/queryscript/src/compile/sql.rs
+++ b/queryscript/src/compile/sql.rs
@@ -144,6 +144,14 @@ pub fn select_star_from(relation: sqlast::TableFactor) -> sqlast::Query {
     )
 }
 
+pub fn select_limit_0(mut query: sqlast::Query) -> sqlast::Query {
+    query.limit = Some(sqlast::Expr::Value(sqlast::Value::Number(
+        "0".to_string(),
+        false,
+    )));
+    query
+}
+
 pub fn with_table_alias(
     table: &sqlast::TableFactor,
     alias: Option<sqlast::TableAlias>,
@@ -1601,8 +1609,11 @@ pub fn schema_infer_load_fn(
     inner_type: CRef<MType>,
 ) -> impl std::future::Future<Output = Result<()>> + Send + 'static {
     async move {
-        let ctx = crate::runtime::Context::new(&schema, crate::runtime::SQLEngineType::DuckDB)
-            .disable_typechecks();
+        let ctx = crate::runtime::Context::new(
+            schema.read()?.folder.clone(),
+            crate::runtime::SQLEngineType::DuckDB,
+        )
+        .disable_typechecks();
         let mut runtime_args = Vec::new();
         for e in args {
             let runtime_expr = e.to_typed_expr().to_runtime_type().context(RuntimeSnafu {

--- a/queryscript/src/compile/traverse.rs
+++ b/queryscript/src/compile/traverse.rs
@@ -807,23 +807,26 @@ impl<V: Visitor<schema::CRef<schema::MType>> + Sync> Visit<V, schema::CRef<schem
         }
 
         Ok(match self {
-            Expr::SQL(e) => {
+            Expr::SQL(e, url) => {
                 let SQL { names, body } = e.as_ref();
                 let mut params = BTreeMap::new();
                 for (name, param) in &names.params {
                     params.insert(name.clone(), param.visit(visitor).await?);
                 }
-                Expr::SQL(Arc::new(SQL {
-                    names: SQLNames {
-                        params,
-                        unbound: names.unbound.clone(),
-                    },
-                    body: match body {
-                        SQLBody::Expr(expr) => SQLBody::Expr(expr.visit_sql(visitor)),
-                        SQLBody::Query(query) => SQLBody::Query(query.visit_sql(visitor)),
-                        SQLBody::Table(table) => SQLBody::Table(table.visit_sql(visitor)),
-                    },
-                }))
+                Expr::SQL(
+                    Arc::new(SQL {
+                        names: SQLNames {
+                            params,
+                            unbound: names.unbound.clone(),
+                        },
+                        body: match body {
+                            SQLBody::Expr(expr) => SQLBody::Expr(expr.visit_sql(visitor)),
+                            SQLBody::Query(query) => SQLBody::Query(query.visit_sql(visitor)),
+                            SQLBody::Table(table) => SQLBody::Table(table.visit_sql(visitor)),
+                        },
+                    }),
+                    url.clone(),
+                )
             }
             Expr::Fn(FnExpr { inner_schema, body }) => Expr::Fn(FnExpr {
                 inner_schema: inner_schema.clone(),
@@ -853,7 +856,6 @@ impl<V: Visitor<schema::CRef<schema::MType>> + Sync> Visit<V, schema::CRef<schem
             }
             Expr::NativeFn(f) => Expr::NativeFn(f.clone()),
             Expr::ContextRef(r) => Expr::ContextRef(r.clone()),
-            Expr::ConnectionObject(u, o) => Expr::ConnectionObject(u.clone(), o.clone()),
             Expr::Unknown => Expr::Unknown,
         })
     }

--- a/queryscript/src/compile/traverse.rs
+++ b/queryscript/src/compile/traverse.rs
@@ -853,6 +853,7 @@ impl<V: Visitor<schema::CRef<schema::MType>> + Sync> Visit<V, schema::CRef<schem
             }
             Expr::NativeFn(f) => Expr::NativeFn(f.clone()),
             Expr::ContextRef(r) => Expr::ContextRef(r.clone()),
+            Expr::ConnectionObject(u, o) => Expr::ConnectionObject(u.clone(), o.clone()),
             Expr::Unknown => Expr::Unknown,
         })
     }

--- a/queryscript/src/compile/unsafe_expr.rs
+++ b/queryscript/src/compile/unsafe_expr.rs
@@ -1,4 +1,3 @@
-use snafu::prelude::*;
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -11,7 +10,6 @@ use crate::compile::schema::*;
 use crate::compile::sql::{compile_reference, select_limit_0};
 use crate::compile::traverse::{SQLVisitor, VisitSQL};
 use crate::compile::Compiler;
-use crate::types::{AtomicType, Type};
 use crate::{
     ast,
     ast::{sqlast, SourceLocation, ToPath},
@@ -100,7 +98,6 @@ pub fn compile_unsafe_expr(
         }
     };
 
-    // XXX We should be able to inline the parameters here too?
     let names = name_collector.names.into_inner();
     let expr = mkcref(Expr::native_sql(Arc::new(SQL {
         names: names.clone(),

--- a/queryscript/src/compile/unsafe_expr.rs
+++ b/queryscript/src/compile/unsafe_expr.rs
@@ -165,11 +165,11 @@ pub fn compile_unsafe_expr(
     };
 
     let names = name_collector.names.into_inner();
-    let expr = mkcref(Expr::SQL(Arc::new(SQL {
+    let expr = mkcref(Expr::native_sql(Arc::new(SQL {
         names: names.clone(),
         body: runnable_body,
     })));
-    let inference_expr = mkcref(Expr::SQL(Arc::new(SQL {
+    let inference_expr = mkcref(Expr::native_sql(Arc::new(SQL {
         names: names,
         body: inference_body,
     })));

--- a/queryscript/src/runtime/context.rs
+++ b/queryscript/src/runtime/context.rs
@@ -28,10 +28,9 @@ impl Context {
         }
     }
 
-    pub fn new(schema: &schema::SchemaRef, engine_type: SQLEngineType) -> Context {
-        let schema = schema.read().unwrap();
+    pub fn new(folder: Option<String>, engine_type: SQLEngineType) -> Context {
         Context {
-            folder: schema.folder.clone(),
+            folder,
             values: BTreeMap::new(),
             sql_engine: new_engine(engine_type),
             disable_typechecks: false,

--- a/queryscript/src/runtime/context.rs
+++ b/queryscript/src/runtime/context.rs
@@ -2,7 +2,6 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use super::sql::{new_engine, SQLEngine, SQLEngineType};
 use crate::ast::Ident;
-use crate::compile::schema;
 use crate::types::Value;
 
 // A basic context with runtime state we can pass into functions. We may want

--- a/queryscript/src/runtime/runtime.rs
+++ b/queryscript/src/runtime/runtime.rs
@@ -96,6 +96,7 @@ pub fn eval<'a>(
                     _ => return rt_unimplemented!("native function: {}", name),
                 }
             }
+            schema::Expr::ConnectionObject(..) => return rt_unimplemented!("Connection object"),
             schema::Expr::FnCall(schema::FnCallExpr {
                 func,
                 args,

--- a/queryscript/src/runtime/runtime.rs
+++ b/queryscript/src/runtime/runtime.rs
@@ -1,5 +1,4 @@
 use futures::future::{BoxFuture, FutureExt};
-use sqlparser::ast as sqlast;
 use std::collections::HashMap;
 
 use crate::compile::schema;

--- a/queryscript/src/runtime/sql.rs
+++ b/queryscript/src/runtime/sql.rs
@@ -16,6 +16,7 @@ pub trait SQLEngine: std::fmt::Debug + Send + Sync {
     async fn eval(
         &self,
         ctx: &Context,
+        url: Option<Arc<crate::compile::ConnectionString>>,
         query: &sqlast::Query,
         params: HashMap<Ident, SQLParam>,
     ) -> Result<Arc<dyn Relation>>;

--- a/queryscript/tests/qs/main.rs
+++ b/queryscript/tests/qs/main.rs
@@ -104,7 +104,8 @@ mod tests {
         let expr = expr.to_runtime_type()?;
 
         let engine_type = runtime::SQLEngineType::DuckDB;
-        let async_ctx = queryscript::runtime::Context::new(&schema, engine_type);
+        let async_ctx =
+            queryscript::runtime::Context::new(schema.read()?.folder.clone(), engine_type);
         let async_expr = expr.clone();
 
         let value = rt.block_on(async move { runtime::eval(&async_ctx, &async_expr).await })?;

--- a/queryscript/tests/sql/db.rs
+++ b/queryscript/tests/sql/db.rs
@@ -95,7 +95,10 @@ impl sqllogictest::AsyncDB for QueryScript {
                     loc: SourceLocation::Unknown,
                 })?;
 
-            let ctx = runtime::Context::new(&self.schema, runtime::SQLEngineType::DuckDB);
+            let ctx = runtime::Context::new(
+                self.schema.read()?.folder.clone(),
+                runtime::SQLEngineType::DuckDB,
+            );
 
             let value = runtime::eval(&ctx, &expr).await.context(RuntimeSnafu {
                 loc: SourceLocation::Unknown,


### PR DESCRIPTION
This change adds support for external connections by treating them like schemas that you can import from. The imported values are always assumed to be expressions with externally resolvable types (similar to `load()`). Also implement basic table inlining, which allows us to push full SQL queries down.

So far, this only works with DuckDB (the existing engine), but as designed, it should be very straightforward to extend to more database systems.