### PR TITLE
Create and use CoerceGeneric instead of relying on one-off logic

### DIFF
--- a/queryscript/src/compile/coerce.rs
+++ b/queryscript/src/compile/coerce.rs
@@ -21,9 +21,12 @@ macro_rules! must_atomic {
     };
 }
 
+#[derive(Clone, Debug)]
 pub enum CoerceOp {
     Binary(BinaryOperator),
+    #[allow(unused)]
     Like,
+    #[allow(unused)]
     IsDistinctFrom,
 }
 

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -6,7 +6,6 @@ use std::path::Path as FilePath;
 use std::sync::Arc;
 
 use crate::compile::builtin_types::{BUILTIN_LOC, GLOBAL_GENERICS, GLOBAL_SCHEMA};
-use crate::compile::coerce::CoerceOp;
 use crate::compile::connection::{ConnectionSchema, ConnectionString};
 use crate::compile::error::*;
 use crate::compile::inference::*;
@@ -1659,20 +1658,6 @@ pub fn gather_schema_externs(schema: Ref<Schema>) -> Result<()> {
     }
 
     Ok(())
-}
-
-pub fn coerce<T: Constrainable + 'static>(
-    compiler: Compiler,
-    op: CoerceOp,
-    left: CRef<T>,
-    right: CRef<T>,
-) -> Result<CRef<T>> {
-    compiler.async_cref(async move {
-        let left = left.await?;
-        let right = right.await?;
-
-        Constrainable::coerce(&op, &left, &right)
-    })
 }
 
 #[cfg(test)]

--- a/queryscript/src/compile/error.rs
+++ b/queryscript/src/compile/error.rs
@@ -100,10 +100,9 @@ pub enum CompileError {
         backtrace: Option<Backtrace>,
     },
 
-    #[snafu(display("Types cannot be coerced: {} and {}", lhs.pretty(), rhs.pretty()))]
+    #[snafu(display("Types cannot be coerced: {}", types.iter().map(Pretty::pretty).collect::<Vec<_>>().join(", ")))]
     CoercionError {
-        lhs: MType,
-        rhs: MType,
+        types: Vec<MType>,
         backtrace: Option<Backtrace>,
         loc: ErrorLocation,
     },
@@ -171,11 +170,10 @@ impl CompileError {
         .build();
     }
 
-    pub fn coercion(loc: ErrorLocation, lhs: &MType, rhs: &MType) -> CompileError {
+    pub fn coercion(loc: ErrorLocation, types: &[MType]) -> CompileError {
         return CoercionSnafu {
             loc,
-            lhs: lhs.clone(),
-            rhs: rhs.clone(),
+            types: types.to_vec(),
         }
         .build();
     }

--- a/queryscript/src/compile/generics.rs
+++ b/queryscript/src/compile/generics.rs
@@ -226,19 +226,23 @@ fn coerce_list(loc: SourceLocation, op: CoerceOp, args: Vec<CRef<MType>>) -> Res
     let resolved_args = args
         .iter()
         .map(|arg| -> Result<MType> {
-            Ok(arg.must().context(RuntimeSnafu { loc })?.read()?.clone())
+            Ok(arg
+                .must()
+                .context(RuntimeSnafu { loc: loc.clone() })?
+                .read()?
+                .clone())
         })
         .collect::<Result<Vec<_>>>()?;
     let runtime_args = resolved_args
         .iter()
         .map(|arg| Ok(arg.to_runtime_type()?))
         .collect::<runtime::error::Result<Vec<_>>>()
-        .context(RuntimeSnafu { loc })?;
+        .context(RuntimeSnafu { loc: loc.clone() })?;
 
     let mut ret = runtime_args[0].clone();
     for arg in &runtime_args[1..] {
         ret = coerce_types(&ret, &op, &arg)
-            .ok_or_else(|| CompileError::coercion(loc, &resolved_args.as_slice()))?;
+            .ok_or_else(|| CompileError::coercion(loc.clone(), &resolved_args.as_slice()))?;
     }
 
     Ok(ret)

--- a/queryscript/src/compile/generics.rs
+++ b/queryscript/src/compile/generics.rs
@@ -14,7 +14,10 @@ use super::{
     Compiler,
 };
 use crate::ast::SourceLocation;
+use crate::compile::coerce::{coerce_types, CoerceOp};
+use crate::compile::sql::combine_crefs;
 use crate::runtime;
+use crate::types;
 use crate::types::{AtomicType, Type};
 
 pub trait Generic: Send + Sync + fmt::Debug {
@@ -42,10 +45,16 @@ pub fn as_generic<T: Generic + 'static>(g: &dyn Generic) -> Option<&T> {
 fn debug_fmt_generic(
     f: &mut std::fmt::Formatter<'_>,
     name: &Ident,
-    arg: &CRef<MType>,
+    args: Vec<CRef<MType>>,
 ) -> std::fmt::Result {
     write!(f, "{}<", name)?;
-    std::fmt::Debug::fmt(arg, f)?;
+    for (i, arg) in args.into_iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+
+        std::fmt::Debug::fmt(&arg, f)?;
+    }
     write!(f, ">")
 }
 
@@ -94,6 +103,7 @@ lazy_static! {
     pub static ref SUM_GENERIC_NAME: Ident = "SumAgg".into();
     pub static ref EXTERNAL_GENERIC_NAME: Ident = "External".into();
     pub static ref CONNECTION_GENERIC_NAME: Ident = "Connection".into();
+    pub static ref COERCE_GENERIC_NAME: Ident = "Coerce".into();
     pub static ref GLOBAL_GENERICS: BTreeMap<Ident, Box<dyn GenericFactory>> = [
         BuiltinGeneric::<SumGeneric>::constructor(),
         BuiltinGeneric::<ExternalType>::constructor(),
@@ -118,7 +128,7 @@ impl GenericConstructor for SumGeneric {
 
 impl std::fmt::Debug for SumGeneric {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        debug_fmt_generic(f, Self::static_name(), &self.0)
+        debug_fmt_generic(f, Self::static_name(), vec![self.0.clone()])
     }
 }
 
@@ -131,7 +141,7 @@ impl Generic for SumGeneric {
         Self::static_name()
     }
 
-    fn to_runtime_type(&self) -> crate::runtime::error::Result<crate::types::Type> {
+    fn to_runtime_type(&self) -> runtime::error::Result<types::Type> {
         let arg = self.0.must()?.read()?.to_runtime_type()?;
 
         // DuckDB's sum function follows the following rules:
@@ -154,7 +164,7 @@ impl Generic for SumGeneric {
                 AtomicType::Float32 | AtomicType::Float64 => AtomicType::Float64,
                 AtomicType::Decimal128(..) | AtomicType::Decimal256(..) => at.clone(),
                 _ => {
-                    return Err(crate::runtime::error::RuntimeError::new(
+                    return Err(runtime::error::RuntimeError::new(
                         format!(
                             "sum(): expected argument to be a numeric ype, got {:?}",
                             arg
@@ -164,7 +174,7 @@ impl Generic for SumGeneric {
                 }
             })),
             _ => {
-                return Err(crate::runtime::error::RuntimeError::new(
+                return Err(runtime::error::RuntimeError::new(
                     format!(
                         "sum(): expected argument to be an atomic type, got {:?}",
                         arg
@@ -180,15 +190,94 @@ impl Generic for SumGeneric {
     }
 
     fn unify(&self, other: &MType) -> Result<()> {
-        // This is a bit of an approximate implementation, since it only works if the inner
-        // type is known.
-        if self.0.is_known()? {
-            let final_type =
-                MType::from_runtime_type(&self.to_runtime_type().context(RuntimeSnafu {
-                    loc: ErrorLocation::Unknown,
-                })?)?;
-            other.unify(&final_type)?;
-        }
+        let other = other.clone();
+        let arg = self.0.clone();
+        arg.constrain(move |arg: Ref<MType>| {
+            let arg = arg.read()?.to_runtime_type().context(RuntimeSnafu {
+                loc: ErrorLocation::Unknown,
+            })?;
+            let final_type = MType::from_runtime_type(&arg)?;
+            other.unify(&final_type)
+        })?;
+        Ok(())
+    }
+}
+
+pub struct CoerceGeneric {
+    op: CoerceOp,
+    args: Vec<CRef<MType>>,
+}
+
+impl CoerceGeneric {
+    pub fn new(op: CoerceOp, args: Vec<CRef<MType>>) -> CoerceGeneric {
+        CoerceGeneric { op, args }
+    }
+
+    fn static_name() -> &'static Ident {
+        &COERCE_GENERIC_NAME
+    }
+}
+
+fn coerce_list(op: CoerceOp, args: Vec<CRef<MType>>) -> runtime::error::Result<types::Type> {
+    if args.len() == 0 {
+        return Ok(types::Type::Atom(AtomicType::Null));
+    }
+    let runtime_args = args
+        .iter()
+        .map(|arg| Ok(arg.must()?.read()?.to_runtime_type()?))
+        .collect::<runtime::error::Result<Vec<_>>>()?;
+
+    let mut ret = runtime_args[0].clone();
+    for arg in &runtime_args[1..] {
+        ret = coerce_types(&ret, &op, &arg).ok_or_else(|| runtime::error::RuntimeError::new(""))?;
+    }
+
+    Ok(ret)
+}
+
+impl std::fmt::Debug for CoerceGeneric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        debug_fmt_generic(f, Self::static_name(), self.args.clone())
+    }
+}
+
+impl Generic for CoerceGeneric {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &Ident {
+        Self::static_name()
+    }
+
+    fn substitute(&self, variables: &BTreeMap<Ident, CRef<MType>>) -> Result<Arc<dyn Generic>> {
+        Ok(Arc::new(Self {
+            op: self.op.clone(),
+            args: self
+                .args
+                .iter()
+                .map(|arg| arg.substitute(variables))
+                .collect::<Result<_>>()?,
+        }))
+    }
+
+    fn to_runtime_type(&self) -> runtime::error::Result<types::Type> {
+        coerce_list(self.op.clone(), self.args.clone())
+    }
+
+    fn unify(&self, other: &MType) -> Result<()> {
+        let op = self.op.clone();
+        let args = self.args.clone();
+        let other = other.clone();
+        combine_crefs(self.args.clone())?.constrain(move |_: Ref<Vec<Ref<MType>>>| {
+            let coerced_type = coerce_list(op.clone(), args.clone()).context(RuntimeSnafu {
+                loc: SourceLocation::Unknown,
+            })?;
+
+            MType::unify(&other, &MType::from_runtime_type(&coerced_type)?)?;
+
+            Ok(())
+        })?;
         Ok(())
     }
 }
@@ -214,7 +303,7 @@ impl GenericConstructor for ExternalType {
 
 impl std::fmt::Debug for ExternalType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        debug_fmt_generic(f, Self::static_name(), &self.0)
+        debug_fmt_generic(f, Self::static_name(), vec![self.0.clone()])
     }
 }
 

--- a/queryscript/src/compile/sql.rs
+++ b/queryscript/src/compile/sql.rs
@@ -9,10 +9,11 @@ use std::sync::Arc;
 
 use crate::compile::coerce::CoerceOp;
 use crate::compile::compile::{
-    coerce, lookup_path, resolve_global_atom, typecheck_path, Compiler, SymbolKind,
+    lookup_path, resolve_global_atom, typecheck_path, Compiler, SymbolKind,
 };
 use crate::compile::error::*;
-use crate::compile::generics::{as_generic, ConnectionType, ExternalType, GenericConstructor};
+use crate::compile::generics;
+use crate::compile::generics::{as_generic, ConnectionType, ExternalType, Generic, GenericConstructor};
 use crate::compile::inference::*;
 use crate::compile::inline::*;
 use crate::compile::schema::*;
@@ -1580,51 +1581,53 @@ fn apply_sqlcast(
 fn coerce_all(
     compiler: &Compiler,
     op: &sqlparser::ast::BinaryOperator,
+    loc: &SourceLocation,
     args: Vec<CTypedSQL>,
-    unknown_debug_name: &str,
 ) -> Result<(CRef<MType>, Vec<CTypedSQL>)> {
-    let mut exprs = Vec::new();
-    let mut iter = args.iter();
+    let arg_types = args.iter().map(|ts| ts.type_.clone()).collect::<Vec<_>>();
+    let generic = Arc::new(generics::CoerceGeneric::new(
+        CoerceOp::Binary(op.clone()),
+        arg_types.clone(),
+    ));
+    let target = mkcref(MType::Generic(Located::new(generic.clone(), loc.clone())));
 
-    let mut target = CRef::new_unknown(unknown_debug_name);
-    if let Some(first) = iter.next() {
-        exprs.push(first.clone());
-        target = first.type_.clone();
-        for next in iter {
-            exprs.push(next.clone());
-            target = coerce(
-                compiler.clone(),
-                CoerceOp::Binary(op.clone()),
-                target,
-                next.type_.clone(),
-            )?;
+    let target_rt = combine_crefs(arg_types.clone())?.then({
+        let loc = loc.clone();
+        move |_: Ref<Vec<Ref<MType>>>| {
+            let target = generic
+                .to_runtime_type()
+                .context(RuntimeSnafu { loc: loc.clone() })?;
+            Ok(mkcref(target))
         }
-    }
+    })?;
 
     let mut ret = Vec::new();
-    for arg in exprs.into_iter() {
-        let target2 = target.clone();
-        let compiler2 = compiler.clone();
-
+    for arg in args.into_iter() {
         ret.push(CTypedSQL {
             type_: target.clone(),
-            sql: compiler.clone().async_cref(async move {
-                let resolved_target = target2.await?;
-                let resolved_arg = arg.type_.await?;
-                let my_type = resolved_arg.read()?;
-                let their_type = resolved_target.read()?;
+            sql: compiler.clone().async_cref({
+                let compiler = compiler.clone();
+                let target = target.clone();
+                let target_rt = target_rt.clone();
+                async move {
+                    let target = target.await?;
+                    let target_rt = target_rt.await?;
+                    let my_type = arg.type_.await?;
+                    let my_type = my_type.read()?;
 
-                Ok(
-                    if their_type.to_runtime_type().context(RuntimeSnafu {
-                        loc: their_type.location(),
-                    })? != my_type.to_runtime_type().context(RuntimeSnafu {
-                        loc: my_type.location(),
-                    })? {
-                        apply_sqlcast(compiler2, arg.sql.clone(), resolved_target.clone())?
-                    } else {
-                        arg.sql
-                    },
-                )
+                    Ok(
+                        if !matches!(&*my_type, MType::Name(_))
+                            && *target_rt.read()?
+                                != my_type.to_runtime_type().context(RuntimeSnafu {
+                                    loc: my_type.location(),
+                                })?
+                        {
+                            apply_sqlcast(compiler, arg.sql.clone(), target.clone())?
+                        } else {
+                            arg.sql
+                        },
+                    )
+                }
             })?,
         })
     }
@@ -2024,22 +2027,13 @@ pub fn compile_sqlexpr(
             use sqlast::BinaryOperator::*;
             let type_ = match op {
                 Plus | Minus | Multiply | Divide => {
-                    let (result_type, casted) = coerce_all(
-                        &compiler,
-                        &op,
-                        vec![cleft, cright],
-                        format!("{:?}", op).as_str(),
-                    )?;
+                    let (result_type, casted) =
+                        coerce_all(&compiler, &op, loc, vec![cleft, cright])?;
                     (cleft, cright) = (casted[0].clone(), casted[1].clone());
                     result_type
                 }
                 Eq | NotEq | Lt | LtEq | Gt | GtEq => {
-                    let (_, casted) = coerce_all(
-                        &compiler,
-                        &op,
-                        vec![cleft, cright],
-                        format!("{:?}", op).as_str(),
-                    )?;
+                    let (_, casted) = coerce_all(&compiler, &op, loc, vec![cleft, cright])?;
                     (cleft, cright) = (casted[0].clone(), casted[1].clone());
                     resolve_global_atom(compiler.clone(), "bool")?
                 }
@@ -2053,12 +2047,8 @@ pub fn compile_sqlexpr(
                             body: SQLBody::Expr(sqlast::Expr::Value(sqlast::Value::Null)),
                         }),
                     };
-                    let (_, casted) = coerce_all(
-                        &compiler,
-                        &op,
-                        vec![cleft, cright, bool_val],
-                        format!("{:?}", op).as_str(),
-                    )?;
+                    let (_, casted) =
+                        coerce_all(&compiler, &op, loc, vec![cleft, cright, bool_val])?;
                     (cleft, cright) = (casted[0].clone(), casted[1].clone());
                     resolve_global_atom(compiler.clone(), "bool")?
                 }
@@ -2164,12 +2154,8 @@ pub fn compile_sqlexpr(
                 c_results.push(ret);
             }
 
-            let (result_type, mut c_results) = coerce_all(
-                &compiler,
-                &sqlast::BinaryOperator::Eq,
-                c_results,
-                "case result",
-            )?;
+            let (result_type, mut c_results) =
+                coerce_all(&compiler, &sqlast::BinaryOperator::Eq, loc, c_results)?;
 
             let c_else_result = match else_result {
                 Some(_) => Some(c_results.pop().unwrap()),

--- a/queryscript/src/compile/sql.rs
+++ b/queryscript/src/compile/sql.rs
@@ -13,7 +13,9 @@ use crate::compile::compile::{
 };
 use crate::compile::error::*;
 use crate::compile::generics;
-use crate::compile::generics::{as_generic, ConnectionType, ExternalType, Generic, GenericConstructor};
+use crate::compile::generics::{
+    as_generic, ConnectionType, ExternalType, Generic, GenericConstructor,
+};
 use crate::compile::inference::*;
 use crate::compile::inline::*;
 use crate::compile::schema::*;
@@ -1586,6 +1588,7 @@ fn coerce_all(
 ) -> Result<(CRef<MType>, Vec<CTypedSQL>)> {
     let arg_types = args.iter().map(|ts| ts.type_.clone()).collect::<Vec<_>>();
     let generic = Arc::new(generics::CoerceGeneric::new(
+        loc.clone(),
         CoerceOp::Binary(op.clone()),
         arg_types.clone(),
     ));
@@ -2730,7 +2733,7 @@ pub fn compile_sqlexpr(
                     names.extend(subquery.names);
 
                     Ok(mkcref(Expr::native_sql(Arc::new(SQL {
-                        names: names,
+                        names,
                         body: SQLBody::Expr(sqlast::Expr::InSubquery {
                             expr: Box::new(expr.body.as_expr()),
                             subquery: Box::new(subquery.body),


### PR DESCRIPTION
Summary: Unifies the logic within `coerce_all` for resolving coercion
types after the arguments are known with the existing system for
generics.
