### PR TITLE
Highlight 'mat'

### DIFF
--- a/extension/syntaxes/QueryScript.plist
+++ b/extension/syntaxes/QueryScript.plist
@@ -74,7 +74,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?i:^\s*((?:export\s+)?(extern|let))\s+(\w+))</string>
+			<string>(?i:^\s*((?:export\s+)?(extern|let|mat))\s+(\w+))</string>
 			<key>name</key>
 			<string>meta.let.sql</string>
 		</dict>


### PR DESCRIPTION
We currently highlight `let` in the VSCode plugin, but not `mat`. This simply updates the `QueryScript.plist` file to do the same for `mat`.