### PR TITLE
Surface area features (`grouping()`, `concat()`, current_date()`, `ifnull()`, `json_extract_string()`, `grouping sets`, `between`, alias overriding)

### DIFF
--- a/queryscript/src/ast/mod.rs
+++ b/queryscript/src/ast/mod.rs
@@ -276,6 +276,7 @@ pub struct FnDef {
     pub name: Located<Ident>,
     pub generics: Vec<Located<Ident>>,
     pub args: Vec<FnArg>,
+    pub variadic_arg: Option<FnArg>,
     pub ret: Option<Type>,
     pub body: FnBody,
 }

--- a/queryscript/src/compile/builtin_types.rs
+++ b/queryscript/src/compile/builtin_types.rs
@@ -60,6 +60,7 @@ fn __native_identity<T>(value T) -> T = native;
 -- Functions
 fn abs<R>(value R) -> R = sql;
 fn concat(args ...string) -> string = sql;
+fn current_date() -> timestamp = sql;
 fn date_trunc(unit string, value timestamp) -> timestamp = sql;
 fn strptime(value text, fmt string) -> timestamp = sql;
 

--- a/queryscript/src/compile/builtin_types.rs
+++ b/queryscript/src/compile/builtin_types.rs
@@ -70,7 +70,7 @@ fn max<R>(value R) -> R = sql;
 fn count<R>(value R) -> bigint = sql;
 fn sum<R>(value R) -> SumAgg<R> = sql;
 fn avg<R>(value R) -> double = sql;
-fn grouping<R>(value R) -> tinyint = sql;
+fn grouping<R>(value R) -> bigint = sql;
 
 -- Window functions
 fn row_number<R>() -> bigint = sql;

--- a/queryscript/src/compile/builtin_types.rs
+++ b/queryscript/src/compile/builtin_types.rs
@@ -59,8 +59,9 @@ fn __native_identity<T>(value T) -> T = native;
 
 -- Functions
 fn abs<R>(value R) -> R = sql;
-fn strptime(value text, fmt string) -> timestamp = sql;
+fn concat(args ...string) -> string = sql;
 fn date_trunc(unit string, value timestamp) -> timestamp = sql;
+fn strptime(value text, fmt string) -> timestamp = sql;
 
 -- Aggs
 fn min<R>(value R) -> R = sql;

--- a/queryscript/src/compile/builtin_types.rs
+++ b/queryscript/src/compile/builtin_types.rs
@@ -62,6 +62,8 @@ fn abs<R>(value R) -> R = sql;
 fn concat(args ...string) -> string = sql;
 fn current_date() -> timestamp = sql;
 fn date_trunc(unit string, value timestamp) -> timestamp = sql;
+fn ifnull<R>(value R, default R) -> R = sql;
+fn json_extract_string(value string, path string) -> string = sql;
 fn strptime(value text, fmt string) -> timestamp = sql;
 
 -- Aggs

--- a/queryscript/src/compile/builtin_types.rs
+++ b/queryscript/src/compile/builtin_types.rs
@@ -68,6 +68,7 @@ fn max<R>(value R) -> R = sql;
 fn count<R>(value R) -> bigint = sql;
 fn sum<R>(value R) -> SumAgg<R> = sql;
 fn avg<R>(value R) -> double = sql;
+fn grouping<R>(value R) -> tinyint = sql;
 
 -- Window functions
 fn row_number<R>() -> bigint = sql;

--- a/queryscript/src/compile/inference.rs
+++ b/queryscript/src/compile/inference.rs
@@ -52,6 +52,28 @@ impl Constrainable for () {
         Ok(())
     }
 }
+
+impl<T> Constrainable for Option<T>
+where
+    T: Constrainable,
+{
+    fn unify(&self, other: &Self) -> Result<()> {
+        match (self, other) {
+            (Some(t1), Some(t2)) => t1.unify(t2),
+            (None, None) => Ok(()),
+            _ => Err(CompileError::internal(
+                ErrorLocation::Unknown,
+                format!(
+                    "cannot unify Option<{}>:\n{:#?}\n{:#?}",
+                    std::any::type_name::<T>(),
+                    self,
+                    other
+                )
+                .as_str(),
+            )),
+        }
+    }
+}
 impl<T> Constrainable for Vec<T>
 where
     T: Constrainable,

--- a/queryscript/src/compile/util.rs
+++ b/queryscript/src/compile/util.rs
@@ -35,6 +35,14 @@ impl<K, V> InsertionOrderMap<K, V> {
         self.map.get_mut(key)
     }
 
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q> + Ord,
+        Q: Ord,
+    {
+        self.map.contains_key(key)
+    }
+
     pub fn insert(&mut self, key: K, value: V) -> Option<V>
     where
         K: Ord + Clone,

--- a/queryscript/src/parser/error.rs
+++ b/queryscript/src/parser/error.rs
@@ -85,6 +85,13 @@ pub enum ParserError {
         loc: ErrorLocation,
     },
 
+    #[snafu(display("Invalid syntax: {}", what))]
+    InvalidSyntax {
+        what: String,
+        backtrace: Option<Backtrace>,
+        loc: ErrorLocation,
+    },
+
     #[snafu(display("{}", sources.first().unwrap()))]
     Multiple {
         // This is assumed to be non-empty
@@ -96,6 +103,10 @@ pub enum ParserError {
 impl ParserError {
     pub fn unimplemented(loc: ErrorLocation, what: &str) -> ParserError {
         UnimplementedSnafu { loc, what }.build()
+    }
+
+    pub fn invalid(loc: ErrorLocation, what: &str) -> ParserError {
+        InvalidSyntaxSnafu { loc, what }.build()
     }
 }
 
@@ -114,6 +125,7 @@ impl PrettyError for ParserError {
             ),
             ParserError::SQLParserError { loc, .. } => loc.clone(),
             ParserError::Unimplemented { loc, .. } => loc.clone(),
+            ParserError::InvalidSyntax { loc, .. } => loc.clone(),
             ParserError::Multiple { sources } => sources.first().unwrap().location(),
         }
     }

--- a/queryscript/src/types/types.rs
+++ b/queryscript/src/types/types.rs
@@ -411,8 +411,6 @@ fn time_unit_precision(tu: &TimeUnit) -> u64 {
     }
 }
 
-// NOTE: Arrow supports the opposite conversion (ArrowDataType -> ParserDataType)
-// in the convert_simple_data_type() function
 impl TryInto<ParserDataType> for &Type {
     type Error = super::error::TypesystemError;
 

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
@@ -1,14 +1,23 @@
 {
     "compile_errors": [
         (
-            Some(
-                2,
-            ),
-            NoSuchEntry {
-                path: [
-                    "concat",
-                ],
+            None,
+            Unimplemented {
+                what: "Expression: Between { expr: Identifier(Ident { value: \"timestamp\", quote_style: None }), negated: false, low: Value(SingleQuotedString(\"2014-01-01\")), high: BinaryOp { left: Function(Function { name: ObjectName([Ident { value: \"current_date\", quote_style: None }]), args: [], over: None, distinct: false, special: false }), op: Plus, right: Interval { value: Value(Number(\"365\", false)), leading_field: Some(Day), leading_precision: None, last_field: None, fractional_seconds_precision: None } } }",
                 backtrace: None,
+                loc: Range(
+                    "tests/qs/metricsplaybook/churned_revenue_cube.qs",
+                    Range {
+                        start: Location {
+                            line: 24,
+                            column: 3,
+                        },
+                        end: Location {
+                            line: 52,
+                            column: 5,
+                        },
+                    },
+                ),
             },
         ),
     ],
@@ -29,7 +38,23 @@
             None,
         ),
         }],
-        "let cte_grouping_sets": ?cte_grouping_sets type?,
+        "let cte_grouping_sets": [{
+        	metric_month Date32,
+        	month_bit Int8,
+        	metric_day Date32,
+        	day_bit Int8,
+        	total_object Utf8,
+        	combination_1 Utf8,
+        	combination_2 Utf8,
+        	combination_3 Utf8,
+        	combination_1_bit Int8,
+        	combination_2_bit Int8,
+        	combination_3_bit Int8,
+        	total_bit Int8,
+        	metric_denominators Null,
+        	metric_calculation Utf8,
+        	metric_value SumAgg<Float64>,
+        }],
         "let cte_prep": [{
         	customer_id Int64,
         	segment Utf8,

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
@@ -17,6 +17,18 @@
             None,
         ),
         }],
+        "let cte_final": [{
+        	metric_model Utf8,
+        	is_snapshot_reliant_metric Boolean,
+        	anchor_date Utf8,
+        	date_grain Utf8,
+        	metric_date Date32,
+        	slice_object Utf8,
+        	slice_dimension Utf8,
+        	slice_value Utf8,
+        	metric_calculation Utf8,
+        	metric_value Float64,
+        }],
         "let cte_grouping_sets": [{
         	metric_month Date32,
         	month_bit Int64,
@@ -74,6 +86,24 @@
                     ),
                 ),
                 value: "| COUNT(*) |\n|----------|\n| 731      |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "count(*)",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| count(*) |\n|----------|\n| 731      |",
             },
         ),
     ],

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
@@ -1,26 +1,5 @@
 {
-    "compile_errors": [
-        (
-            None,
-            Unimplemented {
-                what: "Expression: Between { expr: Identifier(Ident { value: \"timestamp\", quote_style: None }), negated: false, low: Value(SingleQuotedString(\"2014-01-01\")), high: BinaryOp { left: Function(Function { name: ObjectName([Ident { value: \"current_date\", quote_style: None }]), args: [], over: None, distinct: false, special: false }), op: Plus, right: Interval { value: Value(Number(\"365\", false)), leading_field: Some(Day), leading_precision: None, last_field: None, fractional_seconds_precision: None } } }",
-                backtrace: None,
-                loc: Range(
-                    "tests/qs/metricsplaybook/churned_revenue_cube.qs",
-                    Range {
-                        start: Location {
-                            line: 24,
-                            column: 3,
-                        },
-                        end: Location {
-                            line: 52,
-                            column: 5,
-                        },
-                    },
-                ),
-            },
-        ),
-    ],
+    "compile_errors": [],
     "decls": {
         "let contract_stream": [{
         	id Int64,

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
@@ -1,0 +1,58 @@
+{
+    "compile_errors": [
+        (
+            Some(
+                2,
+            ),
+            NoSuchEntry {
+                path: [
+                    "concat",
+                ],
+                backtrace: None,
+            },
+        ),
+    ],
+    "decls": {
+        "let contract_stream": [{
+        	id Int64,
+        	customer_id Int64,
+        	timestamp Timestamp(
+            Microsecond,
+            None,
+        ),
+        	activity Utf8,
+        	revenue_impact Float64,
+        	plan_type Utf8,
+        	activity_occurrence Int64,
+        	activity_repeated_at Timestamp(
+            Microsecond,
+            None,
+        ),
+        }],
+        "let cte_grouping_sets": ?cte_grouping_sets type?,
+        "let cte_prep": [{
+        	customer_id Int64,
+        	segment Utf8,
+        	channel Utf8,
+        	cohort Utf8,
+        	timestamp Timestamp(
+            Microsecond,
+            None,
+        ),
+        	revenue_impact Float64,
+        	activity Utf8,
+        	plan_type Utf8,
+        }],
+        "let dim_customer": [{
+        	id Int64,
+        	segment Utf8,
+        	channel Utf8,
+        	first_contract_signed_date Timestamp(
+            Microsecond,
+            None,
+        ),
+        	cohort Utf8,
+        }],
+    },
+    "queries": [],
+}

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
@@ -19,18 +19,17 @@
         }],
         "let cte_grouping_sets": [{
         	metric_month Date32,
-        	month_bit Int8,
+        	month_bit Int64,
         	metric_day Date32,
-        	day_bit Int8,
+        	day_bit Int64,
         	total_object Utf8,
         	combination_1 Utf8,
         	combination_2 Utf8,
         	combination_3 Utf8,
-        	combination_1_bit Int8,
-        	combination_2_bit Int8,
-        	combination_3_bit Int8,
-        	total_bit Int8,
-        	metric_denominators Null,
+        	combination_1_bit Int64,
+        	combination_2_bit Int64,
+        	combination_3_bit Int64,
+        	total_bit Int64,
         	metric_calculation Utf8,
         	metric_value SumAgg<Float64>,
         }],
@@ -58,5 +57,24 @@
         	cohort Utf8,
         }],
     },
-    "queries": [],
+    "queries": [
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "COUNT(*)",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| COUNT(*) |\n|----------|\n| 731      |",
+            },
+        ),
+    ],
 }

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
@@ -19,9 +19,6 @@ let cte_prep =
 ;
 
 -- XXX This query needs the following:
---  * Support for projection aliases. DuckDB's semantics are something like:
---    add the alias into the scope if it's not already a field, and if the alias
---    is already in the scope (because of a prior projection item), overwrite it.
 -- * concat
 let cte_grouping_sets =
   select

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
@@ -1,0 +1,56 @@
+import * from data;
+
+let cte_prep =
+    select
+        c.id as customer_id,
+        c.segment,
+        c.channel,
+        c.cohort,
+        m.timestamp,
+        m.revenue_impact,
+        m.activity,
+        m.plan_type
+    from
+        "contract_stream" m
+        join "dim_customer" c
+            on m.customer_id = c.id
+    where
+        m.activity = 'customer_churn_committed'
+;
+
+-- XXX This query needs the following:
+--  * Support for projection aliases. DuckDB's semantics are something like:
+--    add the alias into the scope if it's not already a field, and if the alias
+--    is already in the scope (because of a prior projection item), overwrite it.
+-- * concat
+let cte_grouping_sets =
+  select
+    date_trunc('month', timestamp)::date as metric_month,
+      grouping(metric_month) as month_bit,
+    date_trunc('day', timestamp)::date as metric_day,
+      grouping(metric_day) as day_bit,
+    'Total' as total_object,
+    concat('{"dim_name": "segment", "dim_value": "', segment , '"}') as combination_1,
+    concat('{"dim_name": "channel", "dim_value": "', channel , '"}') as combination_2,
+    concat('{"dim_name": "plan_type", "dim_value": "', plan_type , '"}') as combination_3,
+    grouping(combination_1) as combination_1_bit,
+    grouping(combination_2) as combination_2_bit,
+    grouping(combination_3) as combination_3_bit,
+    grouping(total_object) as total_bit,
+    null as metric_denominators,
+    'sum(revenue_impact)' as metric_calculation,
+    sum(revenue_impact) as metric_value
+  from
+    cte_prep
+  where timestamp between '2014-01-01' and current_date() + interval 365 day
+  group by grouping sets (
+    (metric_month, combination_1),
+      (metric_month, combination_2),
+      (metric_month, combination_3),
+      (metric_month, total_object),
+    (metric_day, combination_1),
+      (metric_day, combination_2),
+      (metric_day, combination_3),
+      (metric_day, total_object)
+    )
+;

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
@@ -39,7 +39,7 @@ let cte_grouping_sets =
     sum(revenue_impact) as metric_value
   from
     cte_prep
-  where timestamp between '2014-01-01' and current_date() + interval 365 day
+  where timestamp between '2014-01-01'::timestamp and current_date() + interval 365 day
   group by grouping sets (
     (metric_month, combination_1),
       (metric_month, combination_2),

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
@@ -54,7 +54,6 @@ let cte_grouping_sets =
 
 SELECT COUNT(*) FROM cte_grouping_sets;
 
-/*
 let cte_final = select
         'churned_revenue_cube' as metric_model,
         False as is_snapshot_reliant_metric,
@@ -87,9 +86,10 @@ let cte_final = select
           end as slice_value,
         metric_calculation,
         case
-          when metric_denominators != 0 and metric_value is null then 0
+          when /* metric_denominators != 0 and */ metric_value is null then 0
           else metric_value
         end as metric_value
     from
       cte_grouping_sets;
-*/
+
+select count(*) from cte_final;

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
@@ -18,8 +18,6 @@ let cte_prep =
         m.activity = 'customer_churn_committed'
 ;
 
--- XXX This query needs the following:
--- * concat
 let cte_grouping_sets =
   select
     date_trunc('month', timestamp)::date as metric_month,

--- a/queryscript/tests/qs/metricsplaybook/data.expected
+++ b/queryscript/tests/qs/metricsplaybook/data.expected
@@ -4,35 +4,69 @@
         "let contract_stream": [{
         	id Int64,
         	customer_id Int64,
+        	timestamp Timestamp(
+            Microsecond,
+            None,
+        ),
         	activity Utf8,
+        	revenue_impact Float64,
         	plan_type Utf8,
-        	timestamp Utf8,
         	activity_occurrence Int64,
-        	activity_repeated_at Utf8,
+        	activity_repeated_at Timestamp(
+            Microsecond,
+            None,
+        ),
         }],
         "let dim_customer": [{
         	id Int64,
         	segment Utf8,
         	channel Utf8,
-        	first_contract_signed_date Utf8,
+        	first_contract_signed_date Timestamp(
+            Microsecond,
+            None,
+        ),
         	cohort Utf8,
         }],
-        "let src_contract_stream": External<[{
+        "let src_contract_stream": [{
         	id Int64,
         	customer_id Int64,
-        	timestamp Utf8,
+        	timestamp Timestamp(
+            Microsecond,
+            None,
+        ),
         	activity Utf8,
         	revenue_impact Float64,
         	plan_type Utf8,
-        	activity_occurrence Int64,
-        	activity_repeated_at Utf8,
-        }]>,
-        "let src_dim_customer": External<[{
+        }],
+        "let src_dim_customer": [{
         	id Int64,
         	segment Utf8,
         	channel Utf8,
-        	first_contract_signed_date Utf8,
-        }]>,
+        	first_contract_signed_date Timestamp(
+            Microsecond,
+            None,
+        ),
+        }],
+        "type ContractStream": {
+        	id Int64,
+        	customer_id Int64,
+        	timestamp Timestamp(
+            Microsecond,
+            None,
+        ),
+        	activity Utf8,
+        	revenue_impact Float64,
+        	plan_type Utf8,
+        },
+        "type DimCustomer": {
+        	id Int64,
+        	segment Utf8,
+        	channel Utf8,
+        	first_contract_signed_date Timestamp(
+            Microsecond,
+            None,
+        ),
+        },
     },
     "queries": [
         Ok(
@@ -55,6 +89,16 @@
                                 nullable: true,
                             },
                             Field {
+                                name: "timestamp",
+                                type_: Atom(
+                                    Timestamp(
+                                        Microsecond,
+                                        None,
+                                    ),
+                                ),
+                                nullable: true,
+                            },
+                            Field {
                                 name: "activity",
                                 type_: Atom(
                                     Utf8,
@@ -62,14 +106,14 @@
                                 nullable: true,
                             },
                             Field {
-                                name: "plan_type",
+                                name: "revenue_impact",
                                 type_: Atom(
-                                    Utf8,
+                                    Float64,
                                 ),
                                 nullable: true,
                             },
                             Field {
-                                name: "timestamp",
+                                name: "plan_type",
                                 type_: Atom(
                                     Utf8,
                                 ),
@@ -85,14 +129,17 @@
                             Field {
                                 name: "activity_repeated_at",
                                 type_: Atom(
-                                    Utf8,
+                                    Timestamp(
+                                        Microsecond,
+                                        None,
+                                    ),
                                 ),
                                 nullable: true,
                             },
                         ],
                     ),
                 ),
-                value: "| id | customer_id | activity                     | plan_type | timestamp            | activity_occurrence | activity_repeated_at |\n|----|-------------|------------------------------|-----------|----------------------|---------------------|----------------------|\n| 1  | 156         | customer_churn_committed     | plan4     | 2022-05-23T08:28:22Z | 1                   | 2022-07-18T09:08:23Z |\n| 2  | 258         | customer_churn_committed     | plan3     | 2022-05-10T13:15:51Z | 1                   | null                 |\n| 3  | 296         | contraction_contract_started | plan4     | 2022-02-15T14:03:09Z | 1                   | null                 |\n| 4  | 215         | expansion_contract_started   | plan4     | 2022-06-05T22:31:43Z | 1                   | null                 |\n| 5  | 284         | new_contract_started         | plan4     | 2022-09-03T20:53:59Z | 2                   | null                 |",
+                value: "| id | customer_id | timestamp                 | activity                     | revenue_impact | plan_type | activity_occurrence | activity_repeated_at      |\n|----|-------------|---------------------------|------------------------------|----------------|-----------|---------------------|---------------------------|\n| 1  | 156         | 2022-05-23T08:28:22+00:00 | customer_churn_committed     | 19.2           | plan4     | 1                   | 2022-07-18T09:08:23+00:00 |\n| 2  | 258         | 2022-05-10T13:15:51+00:00 | customer_churn_committed     | 32.0           | plan3     | 1                   | null                      |\n| 3  | 296         | 2022-02-15T14:03:09+00:00 | contraction_contract_started | 30.6           | plan4     | 1                   | null                      |\n| 4  | 215         | 2022-06-05T22:31:43+00:00 | expansion_contract_started   | 25.9           | plan4     | 1                   | null                      |\n| 5  | 284         | 2022-09-03T20:53:59+00:00 | new_contract_started         | 23.4           | plan4     | 2                   | null                      |",
             },
         ),
         Ok(
@@ -124,7 +171,10 @@
                             Field {
                                 name: "first_contract_signed_date",
                                 type_: Atom(
-                                    Utf8,
+                                    Timestamp(
+                                        Microsecond,
+                                        None,
+                                    ),
                                 ),
                                 nullable: true,
                             },
@@ -138,7 +188,7 @@
                         ],
                     ),
                 ),
-                value: "| id | segment  | channel  | first_contract_signed_date | cohort  |\n|----|----------|----------|----------------------------|---------|\n| 1  | segment2 | channel4 | 2022-05-20T11:24:40Z       | 2022-05 |\n| 2  | segment7 | channel1 | 2022-03-13T09:36:31Z       | 2022-03 |\n| 3  | segment3 | channel3 | 2021-12-24T10:37:19Z       | 2021-12 |\n| 4  | segment3 | channel4 | 2022-09-26T22:04:35Z       | 2022-09 |\n| 5  | segment7 | channel3 | 2022-01-21T20:27:11Z       | 2022-01 |",
+                value: "| id | segment  | channel  | first_contract_signed_date | cohort  |\n|----|----------|----------|----------------------------|---------|\n| 1  | segment2 | channel4 | 2022-05-20T11:24:40+00:00  | 2022-05 |\n| 2  | segment7 | channel1 | 2022-03-13T09:36:31+00:00  | 2022-03 |\n| 3  | segment3 | channel3 | 2021-12-24T10:37:19+00:00  | 2021-12 |\n| 4  | segment3 | channel4 | 2022-09-26T22:04:35+00:00  | 2022-09 |\n| 5  | segment7 | channel3 | 2022-01-21T20:27:11+00:00  | 2022-01 |",
             },
         ),
     ],

--- a/queryscript/tests/qs/metricsplaybook/data.qs
+++ b/queryscript/tests/qs/metricsplaybook/data.qs
@@ -1,25 +1,40 @@
-let src_contract_stream = load('raw_csvs/src_contract_stream.csv');
-let src_dim_customer = load('raw_csvs/src_dim_customer.csv');
+-- We define types here because:
+-- 1. The CSV parser doesn't recognize first_contract_signed_date as a timestamp
+-- 2. We omit the (ignored and later replaced) activity_occurence and activity_repeated_at fields
+-- 	  in ContractStream
+type ContractStream {
+	id bigint,
+	customer_id bigint,
+	timestamp timestamp,
+	activity text,
+	revenue_impact double,
+	plan_type text,
+}
+type DimCustomer {
+	id bigint,
+	segment text,
+	channel text,
+	first_contract_signed_date timestamp,
+};
 
-mat contract_stream =
+let src_contract_stream [ContractStream] = load('raw_csvs/src_contract_stream.csv');
+let src_dim_customer [DimCustomer] = load('raw_csvs/src_dim_customer.csv');
+
+export mat contract_stream =
 	select
-		id,
-		customer_id,
-		activity,
-		plan_type,
-		timestamp,
+		*,
 		row_number() over(partition by customer_id, activity order by timestamp asc) as activity_occurrence,
 		lead(timestamp, 1) over(partition by customer_id, activity order by timestamp asc) as activity_repeated_at
 	from
 		src_contract_stream;
 
 
-mat dim_customer =
+export mat dim_customer =
 	select *,
 	-- TODO: We had to add a timestamp cast here, which is not in the original metrics playbook, because
 	-- we do not coerce function argument types (or do not coerce string -> timestamp)
 	-- https://github.com/qscl/queryscript/issues/68
-	substring(date_trunc('month', first_contract_signed_date::timestamp)::text, 1, 7) as cohort
+	substring(date_trunc('month', first_contract_signed_date)::text, 1, 7) as cohort
 	from src_dim_customer;
 
 

--- a/queryscript/tests/qs/simple/binding.expected
+++ b/queryscript/tests/qs/simple/binding.expected
@@ -49,5 +49,49 @@
         	active Boolean,
         },
     },
-    "queries": [],
+    "queries": [
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "a",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "a + 1",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| a | a + 1 |\n|---|-------|\n| 1 | 2     |\n| 2 | 3     |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "a",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| a |\n|---|\n| 1 |",
+            },
+        ),
+    ],
 }

--- a/queryscript/tests/qs/simple/binding.qs
+++ b/queryscript/tests/qs/simple/binding.qs
@@ -8,3 +8,6 @@ let unqualified_ts = SELECT ts FROM events;
 let unqualified_ts_alias = SELECT ts FROM events e;
 let qualified_ts = SELECT events.ts FROM events;
 let qualified_ts_alias = SELECT e.ts FROM events e;
+
+select id as a, a + 1 from users;
+select id as a from users where a = 1;

--- a/queryscript/tests/qs/simple/functions.expected
+++ b/queryscript/tests/qs/simple/functions.expected
@@ -145,6 +145,60 @@
                 value: "| ARRAY_AGG(id)        |\n|----------------------|\n| [Int64(1), Int64(2)] |",
             },
         ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "concat(CAST(id AS TEXT), 'a')",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| concat(CAST(id AS TEXT), 'a') |\n|-------------------------------|\n| 1a                            |\n| 2a                            |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "concat(CAST(id AS TEXT), 'a', 'b')",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| concat(CAST(id AS TEXT), 'a', 'b') |\n|------------------------------------|\n| 1ab                                |\n| 2ab                                |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "concat(CAST(id AS TEXT), 'a', 'b', 'c')",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| concat(CAST(id AS TEXT), 'a', 'b', 'c') |\n|-----------------------------------------|\n| 1abc                                    |\n| 2abc                                    |",
+            },
+        ),
         Err(
             Unimplemented {
                 what: "Function parameters",

--- a/queryscript/tests/qs/simple/functions.qs
+++ b/queryscript/tests/qs/simple/functions.qs
@@ -7,4 +7,9 @@ select count(*) from users;
 select sum(id) from users;
 select avg(id) from users;
 select array_agg(id) from users;
+
+select concat(id::text, 'a') from users;
+select concat(id::text, 'a', 'b') from users;
+select concat(id::text, 'a', 'b', 'c') from users;
+
 select __native_identity(id) from users;


### PR DESCRIPTION
Add several surface area features:
* `grouping()`
* Alias overriding (e.g. `SELECT a + 1 as b, b + 1 as c,...`
* Variadic arguments (fixes #62)
* `concat`, `current_date()`, `ifnull()`
* `BETWEEN`
* `GROUPING SETS`
* `json_extract_string` + `json` extension in duckdb