### PR TITLE
Fix how REPL and LSP handle syntax errors

### DIFF
--- a/queryscript/bin/repl.rs
+++ b/queryscript/bin/repl.rs
@@ -186,7 +186,7 @@ fn run_command(
             }
             Ok(RunCommandResult::Done)
         }
-        Err(_) if parser.is_eof() => Ok(RunCommandResult::More),
+        Err(_) if parser.may_have_more() => Ok(RunCommandResult::More),
         Err(e) => Err(e.into()),
     }
 }

--- a/queryscript/src/error.rs
+++ b/queryscript/src/error.rs
@@ -182,10 +182,6 @@ impl<V, E: MultiError> MultiResult<V, E> {
             )),
         }
     }
-
-    pub fn ok<'s>(&'s self) -> &'s V {
-        &self.result
-    }
 }
 
 #[macro_export]

--- a/queryscript/src/parser/parser.rs
+++ b/queryscript/src/parser/parser.rs
@@ -67,6 +67,15 @@ impl<'a> Parser<'a> {
         self.peek_token().token == Token::EOF
     }
 
+    pub fn may_have_more(&mut self) -> bool {
+        if !self.is_eof() {
+            return false;
+        }
+
+        self.sqlparser.prev_token();
+        return self.sqlparser.next_token() != Token::SemiColon;
+    }
+
     #[must_use]
     pub fn consume_token(&mut self, expected: &Token) -> bool {
         self.sqlparser.consume_token(expected)


### PR DESCRIPTION
Fix some bugs related to syntax errors:

In the REPL, we now check for semicolons to know if a statement _really_ has more (Fixes #11).

We rely on` on_schema()` in the LSP to notify the UI of errors and increment the version (so processes waiting on the latest version can proceed). Prior to this change, however, we didn't call `on_schema()` if the parser failed (we also didn't call it from `compile_schema_ast()`, but luckily do not use that in the LSP).

This change reworks `on_schema()` to _always_ be called, so that the LSP can update its bookkeeping state (Fixes #66, #72)