### PR TITLE
Add support for trailing commas

### DIFF
--- a/queryscript/src/parser/parser.rs
+++ b/queryscript/src/parser/parser.rs
@@ -39,7 +39,14 @@ impl<'a> Parser<'a> {
         let dialect = &GenericDialect {};
         Parser {
             file: file.to_string(),
-            sqlparser: parser::Parser::new_with_locations(tokens, eof, dialect),
+            sqlparser: parser::Parser::new_with_locations(
+                tokens,
+                eof,
+                dialect,
+                Some(parser::ParserOptions {
+                    trailing_commas: true,
+                }),
+            ),
         }
     }
 

--- a/queryscript/tests/qs/faa/flights.expected
+++ b/queryscript/tests/qs/faa/flights.expected
@@ -23,25 +23,6 @@
                 },
                 SQLParserError {
                     source: ParserError(
-                        "Expected ;, found: .",
-                    ),
-                    backtrace: None,
-                    loc: Range(
-                        "tests/qs/faa/flights.qs",
-                        Range {
-                            start: Location {
-                                line: 11,
-                                column: 18,
-                            },
-                            end: Location {
-                                line: 11,
-                                column: 18,
-                            },
-                        },
-                    ),
-                },
-                SQLParserError {
-                    source: ParserError(
                         "Expected identifier, found: :",
                     ),
                     backtrace: None,
@@ -150,25 +131,6 @@
                             end: Location {
                                 line: 23,
                                 column: 64,
-                            },
-                        },
-                    ),
-                },
-                SQLParserError {
-                    source: ParserError(
-                        "Expected ;, found: .",
-                    ),
-                    backtrace: None,
-                    loc: Range(
-                        "tests/qs/faa/flights.qs",
-                        Range {
-                            start: Location {
-                                line: 30,
-                                column: 18,
-                            },
-                            end: Location {
-                                line: 30,
-                                column: 18,
                             },
                         },
                     ),

--- a/queryscript/tests/qs/simple/queries.expected
+++ b/queryscript/tests/qs/simple/queries.expected
@@ -1,17 +1,6 @@
 {
     "compile_errors": [
         (
-            Some(
-                17,
-            ),
-            DuplicateEntry {
-                path: [
-                    "users",
-                ],
-                backtrace: None,
-            },
-        ),
-        (
             None,
             DuplicateEntry {
                 path: [
@@ -26,41 +15,6 @@
                 path: [
                     "id",
                 ],
-                backtrace: None,
-            },
-        ),
-        (
-            None,
-            ScalarSubselectError {
-                what: "should return a single field (not 4)",
-                backtrace: None,
-                loc: Range(
-                    "tests/qs/simple/queries.qs",
-                    Range {
-                        start: Location {
-                            line: 38,
-                            column: 1,
-                        },
-                        end: Location {
-                            line: 38,
-                            column: 97,
-                        },
-                    },
-                ),
-            },
-        ),
-        (
-            None,
-            WrongType {
-                lhs: {
-                	a ?field?,
-                },
-                rhs: {
-                	id Int32,
-                	org_id Int32,
-                	name Utf8,
-                	active Boolean,
-                },
                 backtrace: None,
             },
         ),
@@ -468,42 +422,66 @@
                                 nullable: true,
                             },
                             Field {
-                                name: "org_id",
+                                name: "1",
                                 type_: Atom(
-                                    Int32,
-                                ),
-                                nullable: true,
-                            },
-                            Field {
-                                name: "name",
-                                type_: Atom(
-                                    Utf8,
-                                ),
-                                nullable: true,
-                            },
-                            Field {
-                                name: "active",
-                                type_: Atom(
-                                    Boolean,
+                                    Int64,
                                 ),
                                 nullable: true,
                             },
                         ],
                     ),
                 ),
-                value: "| id | org_id | name | active |\n|----|--------|------|--------|\n| 1  | 1      | Foo  | true   |\n| 2  | 1      | Bar  | false  |",
+                value: "| id | 1 |\n|----|---|\n| 1  | 1 |\n| 2  | 1 |",
             },
         ),
-        Err(
-            StringError {
-                what: "Unknown type cannot exist at runtime (?async_slot?)",
-                backtrace: None,
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "1",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "2",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| 1 | 2 |\n|---|---|\n| 1 | 2 |",
             },
         ),
-        Err(
-            StringError {
-                what: "Unknown type cannot exist at runtime (?async_slot?)",
-                backtrace: None,
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "id",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "a",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| id | a |\n|----|---|\n| 1  | 1 |\n| 2  | 1 |",
             },
         ),
     ],

--- a/queryscript/tests/qs/simple/queries.qs
+++ b/queryscript/tests/qs/simple/queries.qs
@@ -29,10 +29,11 @@ SELECT * EXCLUDE (id, org_id) FROM users ORDER BY name;
 
 SELECT * RENAME (id AS user_id) FROM users ORDER BY id;
 
--- Unsupported
-select u2.* from users join users u2 on users.id = u2.id;
+SELECT
+	id, 1,
+FROM users
+;
 
--- Should error
-select * from users join users on true;
-select count(*) from users, users u2 where users.id = u2.a;
-select description, (select * from users where users.id = events.user_id) from events order by ts;
+SELECT 1, 2, ;
+
+select id, 1 as a, FROM users GROUP BY id, a, ;

--- a/queryscript/tests/qs/simple/queries_error.expected
+++ b/queryscript/tests/qs/simple/queries_error.expected
@@ -1,0 +1,50 @@
+{
+    "compile_errors": [
+        (
+            Some(
+                0,
+            ),
+            NoSuchEntry {
+                path: [
+                    "users",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            Some(
+                1,
+            ),
+            NoSuchEntry {
+                path: [
+                    "users",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            Some(
+                2,
+            ),
+            NoSuchEntry {
+                path: [
+                    "users",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            Some(
+                3,
+            ),
+            NoSuchEntry {
+                path: [
+                    "events",
+                ],
+                backtrace: None,
+            },
+        ),
+    ],
+    "decls": {},
+    "queries": [],
+}

--- a/queryscript/tests/qs/simple/queries_error.qs
+++ b/queryscript/tests/qs/simple/queries_error.qs
@@ -1,0 +1,7 @@
+-- Unsupported
+select u2.* from users join users u2 on users.id = u2.id;
+
+-- Should error
+select * from users join users on true;
+select count(*) from users, users u2 where users.id = u2.a;
+select description, (select * from users where users.id = events.user_id) from events order by ts;


### PR DESCRIPTION
Extends SQL Parser to support trailing commas (also proposed an upstream PR: https://github.com/sqlparser-rs/sqlparser-rs/pull/810).

Fixes #28