### PR TITLE
Adjust the `grid-template-columns` prop for the table view to have a minimum width of 120px

### DIFF
--- a/extension/webview/src/visualizations/table.tsx
+++ b/extension/webview/src/visualizations/table.tsx
@@ -41,7 +41,7 @@ export const Table = ({ data, schema }: TableProps) => {
     <>
       <VSCodeDataGrid
         aria-label="Results"
-        gridTemplateColumns={"1fr ".repeat(fields.length)}
+        gridTemplateColumns={"minmax(120px, 1fr) ".repeat(fields.length)}
       >
         <VSCodeDataGridRow row-type="header">
           {fields.map((field, idx) => (
@@ -54,7 +54,7 @@ export const Table = ({ data, schema }: TableProps) => {
           <VSCodeDataGridRow>
             {fields.map((field, idx) => (
               <VSCodeDataGridCell grid-column={idx + 1}>
-                {normalizeForDisplay(row[field.name])}
+                {normalizeForDisplay(row[field.name as string])}
               </VSCodeDataGridCell>
             ))}
           </VSCodeDataGridRow>


### PR DESCRIPTION
Prior to this change, tables with a lot of columns would show up very smushed (i.e. the width of the column would be as little as one character).

Fixes #58 