### PR TITLE
Notify schema waiters in LSP

### DIFF
--- a/queryscript/bin/lsp.rs
+++ b/queryscript/bin/lsp.rs
@@ -1131,6 +1131,7 @@ impl compile::OnSchema for SchemaRecorder {
             if document.compiling_version.is_some() {
                 document.schema_version = document.compiling_version;
                 document.compiling_version = None;
+                document.schema_signal.notify_waiters();
             }
 
             client.publish_diagnostics(uri, diagnostics, None).await;


### PR DESCRIPTION
When requests to the LSP arrive concurrently with compilation (e.g. a codelens request arrives while a schema is still compiling), we need to wait for the schema to finish compiling its current version. We had a signal in place, but were not notifying on it.