### PR TITLE
Fix loops where the range is a variable (or contains paramaters)

### DIFF
--- a/queryscript/src/compile/builtin_types.rs
+++ b/queryscript/src/compile/builtin_types.rs
@@ -89,7 +89,7 @@ lazy_static! {
             Decl {
                 public: true,
                 extern_: false,
-                fn_arg: false,
+                is_arg: false,
                 name: Ident::with_location(BUILTIN_LOC.clone(), name.to_string()),
                 value: mkcref(MType::Atom(Located::new(
                     type_.clone(),

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -1035,7 +1035,7 @@ fn add_decls<E: Entry>(
                 Decl {
                     public: stmt.export,
                     extern_: *extern_,
-                    fn_arg: false,
+                    is_arg: false,
                     name: name.clone(),
                     value: value.clone(),
                 },
@@ -1439,7 +1439,7 @@ pub fn compile_fn_body(
                 Decl {
                     public: false,
                     extern_: true,
-                    fn_arg: true,
+                    is_arg: true,
                     name: generic.clone(),
                     value: mkcref(MType::Name(generic.clone())),
                 },
@@ -1480,7 +1480,7 @@ pub fn compile_fn_body(
                 Decl {
                     public: false,
                     extern_: true,
-                    fn_arg: true,
+                    is_arg: true,
                     name: arg.name.clone(),
                     value: STypedExpr {
                         type_: stype.clone(),

--- a/queryscript/src/compile/connection.rs
+++ b/queryscript/src/compile/connection.rs
@@ -190,7 +190,7 @@ impl ConnectionSchema {
                     Decl {
                         public: true,
                         extern_: false,
-                        fn_arg: false,
+                        is_arg: false,
                         name: ident.clone(),
                         value: STypedExpr {
                             type_: SType::new_mono(external_type),

--- a/queryscript/src/compile/schema.rs
+++ b/queryscript/src/compile/schema.rs
@@ -1165,7 +1165,7 @@ impl Entry for ExprEntry {
 pub struct Decl<Entry: Clone> {
     pub public: bool,
     pub extern_: bool,
-    pub fn_arg: bool,
+    pub is_arg: bool,
     pub name: Located<Ident>,
     pub value: Entry,
 }

--- a/queryscript/src/compile/schema.rs
+++ b/queryscript/src/compile/schema.rs
@@ -1321,6 +1321,18 @@ impl Schema {
             None => Ok(None),
         }
     }
+
+    /// Creates a child schema with this schema as a parent scope. This is useful
+    /// when entering scope contexts (e.g. functions, loops).
+    pub fn derive(schema: Ref<Schema>) -> Result<Ref<Schema>> {
+        let (file, folder) = {
+            let schema = schema.read()?;
+            (schema.file.clone(), schema.folder.clone())
+        };
+        let inner_schema = Schema::new(file, folder);
+        inner_schema.write()?.parent_scope = Some(schema.clone());
+        Ok(inner_schema)
+    }
 }
 
 pub const SCHEMA_EXTENSIONS: &[&str] = &["qs"];

--- a/queryscript/src/compile/sql.rs
+++ b/queryscript/src/compile/sql.rs
@@ -379,7 +379,7 @@ pub fn compile_reference(
                 Decl {
                     public: true,
                     extern_: false,
-                    fn_arg: false,
+                    is_arg: false,
                     name: Located::new(url.db_name(), loc),
                     value: STypedExpr {
                         type_: SType::new_mono(mkcref(MType::Generic(Located::new(
@@ -425,7 +425,7 @@ pub fn compile_reference(
     };
 
     if let Some(ident) = path.last() {
-        let kind = if decl.fn_arg {
+        let kind = if decl.is_arg {
             SymbolKind::Argument
         } else {
             SymbolKind::Value
@@ -1111,7 +1111,7 @@ where
                         Decl {
                             public: false,
                             extern_: true,
-                            fn_arg: true, // XXX: This should probably be renamed to "arg"
+                            is_arg: true,
                             name: Located::new(name.clone(), SourceLocation::Unknown),
                             value: STypedExpr {
                                 type_: stype,

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
@@ -68,8 +68,34 @@
         ),
         	cohort Utf8,
         }],
+        "let time_slices": [Utf8],
     },
     "queries": [
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "'month'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "'day'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| 'month' | 'day' |\n|---------|-------|\n| month   | day   |",
+            },
+        ),
         Ok(
             TypedValue {
                 type_: List(

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.qs
@@ -18,6 +18,14 @@ let cte_prep =
         m.activity = 'customer_churn_committed'
 ;
 
+let time_slices = ['month', 'day'];
+
+SELECT
+  for slice in time_slices {
+    slice
+  }
+;
+
 let cte_grouping_sets =
   select
     date_trunc('month', timestamp)::date as metric_month,

--- a/queryscript/tests/qs/simple/foreach.expected
+++ b/queryscript/tests/qs/simple/foreach.expected
@@ -1,6 +1,7 @@
 {
     "compile_errors": [],
     "decls": {
+        "let slices": [Utf8],
         "let users": [{
         	id Int32,
         	org_id Int32,
@@ -188,6 +189,31 @@
                     ),
                 ),
                 value: "| 1 | 2 |\n|---|---|\n| 1 | 2 |\n| 1 | 2 |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "'month'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "'day'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| 'month' | 'day' |\n|---------|-------|\n| month   | day   |",
             },
         ),
     ],

--- a/queryscript/tests/qs/simple/foreach.qs
+++ b/queryscript/tests/qs/simple/foreach.qs
@@ -22,6 +22,14 @@ SELECT for item in [1, 2] {
     item
 } FROM users;
 
+let slices = ['month', 'day'];
+
+select
+    for item in slices {
+        item
+    }
+;
+
 /*
 SELECT foreach ([a, b] AS item) {
     item AS IDENT("metric_", item)


### PR DESCRIPTION
Prior to this change, you could only create loops over literals (e.g. `for item in [a,b]`. After this change, you can create loops over array values (e.g. `for item in arr`).