### PR TITLE
Support format strings

### DIFF
--- a/queryscript/src/ast/ident.rs
+++ b/queryscript/src/ast/ident.rs
@@ -6,36 +6,39 @@ use super::{Located, Range, SourceLocation};
 
 // Look into https://crates.io/crates/unicase
 #[derive(Clone)]
-pub struct Ident(UniCase<String>);
+pub struct Ident {
+    s: UniCase<String>,
+    format: bool,
+}
 
 impl AsRef<String> for Ident {
     fn as_ref(&self) -> &String {
-        &self.0
+        &self.s
     }
 }
 
 impl AsRef<str> for Ident {
     fn as_ref(&self) -> &str {
-        &self.0
+        &self.s
     }
 }
 
 impl Into<String> for &Ident {
     fn into(self) -> String {
-        self.0.as_ref().to_string()
+        self.s.as_ref().to_string()
     }
 }
 
 impl AsRef<std::ffi::OsStr> for Ident {
     fn as_ref(&self) -> &std::ffi::OsStr {
-        let s: &str = self.0.as_ref();
+        let s: &str = self.s.as_ref();
         s.as_ref()
     }
 }
 
 impl Into<sqlast::Ident> for &Ident {
     fn into(self) -> sqlast::Ident {
-        sqlast::Ident::with_quote_unlocated('\"', self.0.clone())
+        sqlast::Ident::with_quote_unlocated(if self.format { 'f' } else { '\"' }, self.s.clone())
     }
 }
 
@@ -47,7 +50,10 @@ impl Into<sqlast::ObjectName> for &Ident {
 
 impl From<String> for Ident {
     fn from(s: String) -> Ident {
-        Ident(UniCase::new(s))
+        Ident {
+            s: UniCase::new(s),
+            format: false,
+        }
     }
 }
 
@@ -59,31 +65,31 @@ impl From<&str> for Ident {
 
 impl From<crate::parser::Word> for Ident {
     fn from(w: crate::parser::Word) -> Ident {
-        quoted_string_to_ident(Cow::Owned(w.value), &w.quote_style)
+        quoted_string_to_ident(Cow::Owned(w.value), w.quote_style)
     }
 }
 
 impl From<sqlast::Ident> for Ident {
     fn from(w: sqlast::Ident) -> Ident {
-        quoted_string_to_ident(Cow::Owned(w.value), &w.quote_style)
+        quoted_string_to_ident(Cow::Owned(w.value), w.quote_style)
     }
 }
 
 impl From<&sqlast::Ident> for Ident {
     fn from(w: &sqlast::Ident) -> Ident {
-        quoted_string_to_ident(Cow::Borrowed(&w.value), &w.quote_style)
+        quoted_string_to_ident(Cow::Borrowed(&w.value), w.quote_style)
     }
 }
 
 impl std::fmt::Display for Ident {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.s)
     }
 }
 
 impl std::fmt::Debug for Ident {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+        write!(f, "{:?}", self.s)
     }
 }
 
@@ -93,32 +99,34 @@ impl std::fmt::Debug for Ident {
 // lowercase identifiers if they are not quoted. Snowflake automatically uppercases them.
 // We may want to add a flag to the compiler that lets you control this behavior, but for now
 // we stick with DuckDB's which is most like a traditional programming language.
-fn quoted_string_to_ident(value: Cow<String>, _quote_style: &Option<char>) -> Ident {
-    value.into_owned().into()
+fn quoted_string_to_ident(value: Cow<String>, quote_style: Option<char>) -> Ident {
+    let mut ident: Ident = value.into_owned().into();
+    ident.format = matches!(quote_style, Some('f'));
+    ident
 }
 
 impl PartialOrd for Ident {
     fn partial_cmp(&self, other: &Ident) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
+        self.s.partial_cmp(&other.s)
     }
 }
 
 impl Ord for Ident {
     fn cmp(&self, other: &Ident) -> std::cmp::Ordering {
-        self.0.cmp(&other.0)
+        self.s.cmp(&other.s)
     }
 }
 
 impl PartialEq for Ident {
     fn eq(&self, other: &Ident) -> bool {
-        self.0 == other.0
+        self.s == other.s
     }
 }
 impl Eq for Ident {}
 
 impl std::hash::Hash for Ident {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state)
+        self.s.hash(state)
     }
 }
 
@@ -156,6 +164,10 @@ impl Ident {
 
     pub fn as_str(&self) -> &str {
         self.as_ref()
+    }
+
+    pub fn is_format(&self) -> bool {
+        self.format
     }
 }
 

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -144,7 +144,8 @@ pub struct ParsedFile {
 
 #[derive(Debug, Clone)]
 pub struct Compiler {
-    runtime: Ref<tokio::runtime::Runtime>,
+    // XXX Undo this
+    pub runtime: Ref<tokio::runtime::Runtime>,
     data: Ref<CompilerData>,
     builtins: Ref<Schema>,
 }

--- a/queryscript/src/compile/compile.rs
+++ b/queryscript/src/compile/compile.rs
@@ -144,8 +144,7 @@ pub struct ParsedFile {
 
 #[derive(Debug, Clone)]
 pub struct Compiler {
-    // XXX Undo this
-    pub runtime: Ref<tokio::runtime::Runtime>,
+    runtime: Ref<tokio::runtime::Runtime>,
     data: Ref<CompilerData>,
     builtins: Ref<Schema>,
 }

--- a/queryscript/src/compile/error.rs
+++ b/queryscript/src/compile/error.rs
@@ -135,6 +135,13 @@ pub enum CompileError {
         loc: ErrorLocation,
     },
 
+    #[snafu(display("Unknown format string parameter: {}", name))]
+    UnknownFormatStringParamError {
+        name: String,
+        backtrace: Option<Backtrace>,
+        loc: ErrorLocation,
+    },
+
     #[snafu(display("{}", sources.first().unwrap()))]
     Multiple {
         // This is assumed to be non-empty
@@ -217,6 +224,14 @@ impl CompileError {
         .build();
     }
 
+    pub fn unknown_format_param(loc: ErrorLocation, name: &str) -> CompileError {
+        return UnknownFormatStringParamSnafu {
+            loc,
+            name: name.to_string(),
+        }
+        .build();
+    }
+
     pub fn internal(loc: ErrorLocation, what: &str) -> CompileError {
         return InternalSnafu {
             loc,
@@ -289,6 +304,7 @@ impl PrettyError for CompileError {
             CompileError::ScalarSubselectError { loc, .. } => loc.clone(),
             CompileError::InvalidConnectionError { loc, .. } => loc.clone(),
             CompileError::InvalidForEachError { loc, .. } => loc.clone(),
+            CompileError::UnknownFormatStringParamError { loc, .. } => loc.clone(),
             CompileError::Multiple { sources } => sources.first().unwrap().location(),
         }
     }

--- a/queryscript/src/compile/error.rs
+++ b/queryscript/src/compile/error.rs
@@ -135,13 +135,6 @@ pub enum CompileError {
         loc: ErrorLocation,
     },
 
-    #[snafu(display("Unknown format string parameter: {}", name))]
-    UnknownFormatStringParamError {
-        name: String,
-        backtrace: Option<Backtrace>,
-        loc: ErrorLocation,
-    },
-
     #[snafu(display("{}", sources.first().unwrap()))]
     Multiple {
         // This is assumed to be non-empty
@@ -224,14 +217,6 @@ impl CompileError {
         .build();
     }
 
-    pub fn unknown_format_param(loc: ErrorLocation, name: &str) -> CompileError {
-        return UnknownFormatStringParamSnafu {
-            loc,
-            name: name.to_string(),
-        }
-        .build();
-    }
-
     pub fn internal(loc: ErrorLocation, what: &str) -> CompileError {
         return InternalSnafu {
             loc,
@@ -304,7 +289,6 @@ impl PrettyError for CompileError {
             CompileError::ScalarSubselectError { loc, .. } => loc.clone(),
             CompileError::InvalidConnectionError { loc, .. } => loc.clone(),
             CompileError::InvalidForEachError { loc, .. } => loc.clone(),
-            CompileError::UnknownFormatStringParamError { loc, .. } => loc.clone(),
             CompileError::Multiple { sources } => sources.first().unwrap().location(),
         }
     }

--- a/queryscript/src/compile/fmtstring.rs
+++ b/queryscript/src/compile/fmtstring.rs
@@ -64,17 +64,15 @@ impl StringFormatter {
         }
     }
 
-    pub fn format(self, names: BTreeMap<String, String>) -> crate::compile::error::Result<String> {
+    pub fn format(self, names: BTreeMap<String, String>) -> String {
         self.segments
             .into_iter()
             .map(|s| match s {
-                Segment::Literal(s) => Ok(s),
-                Segment::Format(s) => names.get(&s).cloned().ok_or_else(|| {
-                    CompileError::unknown_format_param(
-                        self.loc.clone(),
-                        &format!("Unknown format specifier: {}", s),
-                    )
-                }),
+                Segment::Literal(s) => s,
+                Segment::Format(s) => names
+                    .get(&s)
+                    .cloned()
+                    .expect(&format!("Unknown format specifier: {}", s)),
             })
             .collect()
     }
@@ -127,7 +125,7 @@ impl StringFormatter {
             value_names.insert(name, result.to_string());
         }
 
-        Ok(self.format(value_names)?)
+        Ok(self.format(value_names))
     }
 }
 

--- a/queryscript/src/compile/fmtstring.rs
+++ b/queryscript/src/compile/fmtstring.rs
@@ -1,0 +1,211 @@
+use snafu::prelude::*;
+use std::collections::BTreeMap;
+
+use crate::ast::SourceLocation;
+
+use super::error::*;
+use super::schema::*;
+use super::{compile_reference, Compiler, Schema};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Segment {
+    Literal(String),
+    Format(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct StringFormatter {
+    pub loc: SourceLocation,
+    pub segments: Vec<Segment>,
+}
+
+impl StringFormatter {
+    pub fn build(s: String, loc: SourceLocation) -> StringFormatter {
+        let mut segments = Vec::new();
+        let mut in_format = false;
+        let mut curr = "".to_string();
+        let mut iter = s.chars().peekable();
+        loop {
+            let tok = match iter.next() {
+                Some(c) => c,
+                None => break,
+            };
+            if tok == '{' && matches!(iter.peek(), Some('{')) {
+                curr.push(iter.next().unwrap());
+                continue;
+            } else if tok == '}' && matches!(iter.peek(), Some('}')) {
+                curr.push(iter.next().unwrap());
+                continue;
+            }
+            if tok == '{' && !in_format {
+                in_format = true;
+                if curr.len() > 0 {
+                    segments.push(Segment::Literal(curr.drain(..).collect()));
+                }
+            } else if tok == '}' && in_format {
+                in_format = false;
+                if curr.len() > 0 {
+                    // NOTE: Eventually we could support positional arguments with {}
+                    segments.push(Segment::Format(curr.drain(..).collect()));
+                }
+            } else {
+                curr.push(tok);
+            }
+        }
+        if curr.len() > 0 {
+            if in_format {
+                curr = "{".to_string() + &curr;
+            }
+            segments.push(Segment::Literal(curr))
+        }
+        StringFormatter {
+            loc,
+            segments: segments,
+        }
+    }
+
+    pub fn format(self, names: BTreeMap<String, String>) -> crate::compile::error::Result<String> {
+        self.segments
+            .into_iter()
+            .map(|s| match s {
+                Segment::Literal(s) => Ok(s),
+                Segment::Format(s) => names.get(&s).cloned().ok_or_else(|| {
+                    CompileError::unknown_format_param(
+                        self.loc.clone(),
+                        &format!("Unknown format specifier: {}", s),
+                    )
+                }),
+            })
+            .collect()
+    }
+
+    pub fn resolve_format_string(
+        self,
+        compiler: &Compiler,
+        schema: &Ref<Schema>,
+        loc: &SourceLocation,
+    ) -> Result<String> {
+        let mut names = BTreeMap::new();
+        for segment in self.segments.iter() {
+            let param_name = match segment {
+                Segment::Literal(_) => continue,
+                Segment::Format(f) => f,
+            };
+
+            if names.contains_key(param_name) {
+                continue;
+            }
+
+            let names_ident: Located<Ident> =
+                Located::new(param_name.clone().into(), SourceLocation::Unknown);
+            let expr = compile_reference(
+                compiler.clone(),
+                schema.clone(),
+                // TODO We should parse the innards of a format string as a path, instead of
+                // a single ident
+                &vec![names_ident],
+            )?;
+
+            names.insert(param_name.clone(), expr);
+        }
+
+        let mut ctx = crate::runtime::Context::new(
+            schema.read()?.folder.clone(),
+            crate::runtime::SQLEngineType::DuckDB,
+        );
+
+        let mut value_names = BTreeMap::new();
+        for (name, expr) in names {
+            let te = expr
+                .to_runtime_type()
+                .context(RuntimeSnafu { loc: loc.clone() })?;
+            let result = futures::executor::block_on(async {
+                crate::runtime::eval(&mut ctx, &te)
+                    .await
+                    .context(RuntimeSnafu { loc: loc.clone() })
+            })?;
+            value_names.insert(name, result.to_string());
+        }
+
+        Ok(self.format(value_names)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_format_strings() {
+        let cases = vec![
+            ("foo", vec![Segment::Literal("foo".to_string())]),
+            (
+                "foo{bar}",
+                vec![
+                    Segment::Literal("foo".to_string()),
+                    Segment::Format("bar".to_string()),
+                ],
+            ),
+            (
+                "{foo}bar",
+                vec![
+                    Segment::Format("foo".to_string()),
+                    Segment::Literal("bar".to_string()),
+                ],
+            ),
+            (
+                "foo{bar}baz",
+                vec![
+                    Segment::Literal("foo".to_string()),
+                    Segment::Format("bar".to_string()),
+                    Segment::Literal("baz".to_string()),
+                ],
+            ),
+            (
+                "foo{bar}baz{qux}",
+                vec![
+                    Segment::Literal("foo".to_string()),
+                    Segment::Format("bar".to_string()),
+                    Segment::Literal("baz".to_string()),
+                    Segment::Format("qux".to_string()),
+                ],
+            ),
+            (
+                "foo{bar } baz }",
+                vec![
+                    Segment::Literal("foo".to_string()),
+                    Segment::Format("bar ".to_string()),
+                    Segment::Literal(" baz }".to_string()),
+                ],
+            ),
+            (
+                "foo{bar { baz }",
+                vec![
+                    Segment::Literal("foo".to_string()),
+                    Segment::Format("bar { baz ".to_string()),
+                ],
+            ),
+            (
+                "foo{bar { baz ",
+                vec![
+                    Segment::Literal("foo".to_string()),
+                    Segment::Literal("{bar { baz ".to_string()),
+                ],
+            ),
+            (
+                "foo{}bar",
+                vec![
+                    Segment::Literal("foo".to_string()),
+                    Segment::Literal("bar".to_string()),
+                ],
+            ),
+            ("foo{{}}bar", vec![Segment::Literal("foo{}bar".to_string())]),
+        ];
+
+        for case in cases {
+            let (input, expected) = case;
+            let formatter = StringFormatter::build(input.to_string(), SourceLocation::Unknown);
+            assert_eq!(expected, formatter.segments);
+        }
+    }
+}

--- a/queryscript/src/compile/inference.rs
+++ b/queryscript/src/compile/inference.rs
@@ -10,6 +10,8 @@ use crate::compile::error::*;
 use crate::compile::schema::{mkref, Ref};
 use crate::runtime;
 
+use super::schema::Located;
+
 pub trait Constrainable: Clone + fmt::Debug + Send + Sync {
     fn unify(&self, other: &Self) -> Result<()> {
         Err(CompileError::internal(
@@ -47,6 +49,8 @@ where
 }
 
 impl Constrainable for Ident {}
+impl Constrainable for Located<Ident> {}
+impl Constrainable for String {}
 impl Constrainable for () {
     fn unify(&self, _other: &Self) -> Result<()> {
         Ok(())
@@ -74,6 +78,7 @@ where
         }
     }
 }
+
 impl<T> Constrainable for Vec<T>
 where
     T: Constrainable,
@@ -99,6 +104,7 @@ where
         Ok(())
     }
 }
+
 impl<K, V> Constrainable for BTreeMap<K, V>
 where
     K: Constrainable,

--- a/queryscript/src/compile/mod.rs
+++ b/queryscript/src/compile/mod.rs
@@ -5,6 +5,7 @@ pub mod compile;
 mod connection;
 pub mod error;
 mod external;
+mod fmtstring;
 mod generics;
 pub mod inference;
 pub mod inline;

--- a/queryscript/src/runtime/duckdb/engine.rs
+++ b/queryscript/src/runtime/duckdb/engine.rs
@@ -161,7 +161,7 @@ impl DuckDBEngine {
 
         scalar_params.sort();
         let normalizer = DuckDBNormalizer::new(&scalar_params, &relation_params);
-        let query = normalizer.normalize(&query);
+        let query = normalizer.normalize(&query).as_result()?;
 
         {
             let relations = &mut conn_state.relations.lock()?;

--- a/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
+++ b/queryscript/tests/qs/metricsplaybook/churned_revenue_cube.expected
@@ -1,5 +1,60 @@
 {
-    "compile_errors": [],
+    "compile_errors": [
+        (
+            None,
+            NoSuchEntry {
+                path: [
+                    "combination_1_bit",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            None,
+            NoSuchEntry {
+                path: [
+                    "combination_2_bit",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            None,
+            NoSuchEntry {
+                path: [
+                    "combination_3_bit",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            None,
+            NoSuchEntry {
+                path: [
+                    "combination_1",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            None,
+            NoSuchEntry {
+                path: [
+                    "combination_2",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            None,
+            NoSuchEntry {
+                path: [
+                    "combination_3",
+                ],
+                backtrace: None,
+            },
+        ),
+    ],
     "decls": {
         "let contract_stream": [{
         	id Int64,
@@ -17,30 +72,19 @@
             None,
         ),
         }],
-        "let cte_final": [{
-        	metric_model Utf8,
-        	is_snapshot_reliant_metric Boolean,
-        	anchor_date Utf8,
-        	date_grain Utf8,
-        	metric_date Date32,
-        	slice_object Utf8,
-        	slice_dimension Utf8,
-        	slice_value Utf8,
-        	metric_calculation Utf8,
-        	metric_value Float64,
-        }],
+        "let cte_final": [?async_slot?],
         "let cte_grouping_sets": [{
         	metric_month Date32,
         	month_bit Int64,
         	metric_day Date32,
         	day_bit Int64,
+        	combination_segment Utf8,
+        	segment_bit Int64,
+        	combination_channel Utf8,
+        	channel_bit Int64,
+        	combination_plan_type Utf8,
+        	plan_type_bit Int64,
         	total_object Utf8,
-        	combination_1 Utf8,
-        	combination_2 Utf8,
-        	combination_3 Utf8,
-        	combination_1_bit Int64,
-        	combination_2_bit Int64,
-        	combination_3_bit Int64,
         	total_bit Int64,
         	metric_calculation Utf8,
         	metric_value SumAgg<Float64>,
@@ -58,6 +102,7 @@
         	activity Utf8,
         	plan_type Utf8,
         }],
+        "let date_slices": [Utf8],
         "let dim_customer": [{
         	id Int64,
         	segment Utf8,
@@ -68,34 +113,9 @@
         ),
         	cohort Utf8,
         }],
-        "let time_slices": [Utf8],
+        "let metric_slices": [Utf8],
     },
     "queries": [
-        Ok(
-            TypedValue {
-                type_: List(
-                    Record(
-                        [
-                            Field {
-                                name: "'month'",
-                                type_: Atom(
-                                    Utf8,
-                                ),
-                                nullable: true,
-                            },
-                            Field {
-                                name: "'day'",
-                                type_: Atom(
-                                    Utf8,
-                                ),
-                                nullable: true,
-                            },
-                        ],
-                    ),
-                ),
-                value: "| 'month' | 'day' |\n|---------|-------|\n| month   | day   |",
-            },
-        ),
         Ok(
             TypedValue {
                 type_: List(
@@ -114,22 +134,10 @@
                 value: "| COUNT(*) |\n|----------|\n| 731      |",
             },
         ),
-        Ok(
-            TypedValue {
-                type_: List(
-                    Record(
-                        [
-                            Field {
-                                name: "count(*)",
-                                type_: Atom(
-                                    Int64,
-                                ),
-                                nullable: true,
-                            },
-                        ],
-                    ),
-                ),
-                value: "| count(*) |\n|----------|\n| 731      |",
+        Err(
+            StringError {
+                what: "Unknown type cannot exist at runtime (?async_slot?)",
+                backtrace: None,
             },
         ),
     ],

--- a/queryscript/tests/qs/simple/foreach.expected
+++ b/queryscript/tests/qs/simple/foreach.expected
@@ -1,7 +1,10 @@
 {
     "compile_errors": [],
     "decls": {
+        "let id_types": [Utf8],
+        "let numbers": [Utf8],
         "let slices": [Utf8],
+        "let strings": [Utf8],
         "let users": [{
         	id Int32,
         	org_id Int32,
@@ -239,6 +242,166 @@
                     ),
                 ),
                 value: "| metric_id | metric_org_id |\n|-----------|---------------|\n| 1         | 1             |\n| 2         | 1             |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Atom(
+                        Utf8,
+                    ),
+                ),
+                value: "[id, org_id]",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "strings",
+                                type_: List(
+                                    Atom(
+                                        Utf8,
+                                    ),
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| strings      |\n|--------------|\n| [id, org_id] |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Atom(
+                        Utf8,
+                    ),
+                ),
+                value: "[id, org_id]",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "numbers",
+                                type_: List(
+                                    Atom(
+                                        Utf8,
+                                    ),
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| numbers      |\n|--------------|\n| [id, org_id] |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "'id'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "'org_id'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| 'id' | 'org_id' |\n|------|----------|\n| id   | org_id   |\n| id   | org_id   |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "'id'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "'org_id'",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| 'id' | 'org_id' |\n|------|----------|\n| id   | org_id   |\n| id   | org_id   |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "id",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "org_id",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| id | org_id |\n|----|--------|\n| 1  | 1      |\n| 2  | 1      |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "id",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "org_id",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| id | org_id |\n|----|--------|\n| 1  | 1      |\n| 2  | 1      |",
             },
         ),
     ],

--- a/queryscript/tests/qs/simple/foreach.expected
+++ b/queryscript/tests/qs/simple/foreach.expected
@@ -216,5 +216,30 @@
                 value: "| 'month' | 'day' |\n|---------|-------|\n| month   | day   |",
             },
         ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "metric_id",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "metric_org_id",
+                                type_: Atom(
+                                    Int32,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| metric_id | metric_org_id |\n|-----------|---------------|\n| 1         | 1             |\n| 2         | 1             |",
+            },
+        ),
     ],
 }

--- a/queryscript/tests/qs/simple/foreach.qs
+++ b/queryscript/tests/qs/simple/foreach.qs
@@ -34,6 +34,34 @@ SELECT for item in [id, org_id] {
     item AS f"metric_{item}"
 } FROM users;
 
+let strings = ['id', 'org_id'];
+let numbers = ['id', 'org_id'];
+
+strings;
+SELECT strings;
+
+numbers;
+SELECT numbers;
+
+SELECT for item in numbers {
+    item
+} FROM users;
+
+
+SELECT for item in strings {
+    item
+} FROM users;
+
+-- Idents
+SELECT for item in strings {
+    f"{item}"
+} FROM users;
+
+let id_types = ['', 'org_'];
+SELECT for item in id_types {
+    f"{item}id"
+} FROM users;
+
 /*
 SELECT for item in [users, org_id] {
     item

--- a/queryscript/tests/qs/simple/foreach.qs
+++ b/queryscript/tests/qs/simple/foreach.qs
@@ -30,11 +30,9 @@ select
     }
 ;
 
-/*
-SELECT foreach ([a, b] AS item) {
-    item AS IDENT("metric_", item)
-} FROM foo;
-*/
+SELECT for item in [id, org_id] {
+    item AS f"metric_{item}"
+} FROM users;
 
 /*
 SELECT for item in [users, org_id] {

--- a/queryscript/tests/qs/trivial/fmt.expected
+++ b/queryscript/tests/qs/trivial/fmt.expected
@@ -1,0 +1,94 @@
+{
+    "compile_errors": [
+        (
+            Some(
+                4,
+            ),
+            Unimplemented {
+                what: "Format string values: f'{ss}'",
+                backtrace: None,
+                loc: Range(
+                    "tests/qs/trivial/fmt.qs",
+                    Range {
+                        start: Location {
+                            line: 6,
+                            column: 1,
+                        },
+                        end: Location {
+                            line: 6,
+                            column: 14,
+                        },
+                    },
+                ),
+            },
+        ),
+    ],
+    "decls": {
+        "let s": Utf8,
+        "let slices": [Utf8],
+        "let ss": Utf8,
+    },
+    "queries": [
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "foo_month",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| foo_month |\n|-----------|\n| 1         |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "s",
+                                type_: Atom(
+                                    Int64,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| s |\n|---|\n| 1 |",
+            },
+        ),
+        Ok(
+            TypedValue {
+                type_: List(
+                    Record(
+                        [
+                            Field {
+                                name: "metric_month",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                            Field {
+                                name: "metric_day",
+                                type_: Atom(
+                                    Utf8,
+                                ),
+                                nullable: true,
+                            },
+                        ],
+                    ),
+                ),
+                value: "| metric_month | metric_day |\n|--------------|------------|\n| month        | day        |",
+            },
+        ),
+    ],
+}

--- a/queryscript/tests/qs/trivial/fmt.expected
+++ b/queryscript/tests/qs/trivial/fmt.expected
@@ -1,28 +1,5 @@
 {
-    "compile_errors": [
-        (
-            Some(
-                4,
-            ),
-            Unimplemented {
-                what: "Format string values: f'{ss}'",
-                backtrace: None,
-                loc: Range(
-                    "tests/qs/trivial/fmt.qs",
-                    Range {
-                        start: Location {
-                            line: 6,
-                            column: 1,
-                        },
-                        end: Location {
-                            line: 6,
-                            column: 14,
-                        },
-                    },
-                ),
-            },
-        ),
-    ],
+    "compile_errors": [],
     "decls": {
         "let s": Utf8,
         "let slices": [Utf8],

--- a/queryscript/tests/qs/trivial/fmt.qs
+++ b/queryscript/tests/qs/trivial/fmt.qs
@@ -1,0 +1,14 @@
+let s = 'month';
+let ss = 's';
+
+select 1 as f"foo_{s}";
+select f"{ss}" from (select 1 as "s"); -- should be the value 1
+select f'{ss}'; -- should be the value s
+
+let slices = ['month', 'day'];
+
+select
+    for item in slices {
+        item AS f"metric_{item}"
+    }
+;

--- a/queryscript/tests/qs/trivial/fmt_errors.expected
+++ b/queryscript/tests/qs/trivial/fmt_errors.expected
@@ -1,0 +1,66 @@
+{
+    "compile_errors": [
+        (
+            Some(
+                0,
+            ),
+            NoSuchEntry {
+                path: [
+                    "s",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            Some(
+                1,
+            ),
+            NoSuchEntry {
+                path: [
+                    "ss",
+                ],
+                backtrace: None,
+            },
+        ),
+        (
+            Some(
+                2,
+            ),
+            Unimplemented {
+                what: "Format string values: f'{ss}'",
+                backtrace: None,
+                loc: Range(
+                    "tests/qs/trivial/fmt_errors.qs",
+                    Range {
+                        start: Location {
+                            line: 3,
+                            column: 1,
+                        },
+                        end: Location {
+                            line: 3,
+                            column: 14,
+                        },
+                    },
+                ),
+            },
+        ),
+        (
+            None,
+            NoSuchEntry {
+                path: [
+                    "slices",
+                ],
+                backtrace: None,
+            },
+        ),
+    ],
+    "decls": {},
+    "queries": [
+        Err(
+            StringError {
+                what: "Unknown type cannot exist at runtime (?slot?)",
+                backtrace: None,
+            },
+        ),
+    ],
+}

--- a/queryscript/tests/qs/trivial/fmt_errors.qs
+++ b/queryscript/tests/qs/trivial/fmt_errors.qs
@@ -1,13 +1,6 @@
-let s = 'month';
-let ss = 's';
-
 select 1 as f"foo_{s}";
 select f"{ss}" from (select 1 as "s"); -- should be the value 1
-
--- TODO
--- select f'{ss}'; -- should be the value s
-
-let slices = ['month', 'day'];
+select f'{ss}'; -- should be the value s
 
 select
     for item in slices {


### PR DESCRIPTION
This change introduces a new syntax for format strings, `f"foo_{bar}"`, where (in this example) `bar` is expected to be a variable in scope while binding the string. It's accompanied by a parser change (https://github.com/qscl/sqlparser-rs/commit/24541bf119ae47feeb8ae73f9ddc93cc381e75b5).

Format strings work globally, e.g.

```
let foo = 'a';
SELECT 1 as f"{foo}";
```

and in loops, e.g.

```
let foo = ['a', 'b']';
SELECT for name in foo {
  f"col_{name}"
} FROM t
```

(where in this example, `t` would have columns `col_a` and `col_b`).

Of note, the format string variables are in compiler scope (not sql scope), for a few reasons:

- SQL targets don't support the format strings so they have to be resolved at compile time
- And even if they did, formatted idents affect the type of the query, which we need to know at compile time
- Compiler scoped variables are `TypedExpr`s which we can eval
- Inside of loops, we create a string for each range's value and add it to the schema.

Currently, format strings are only supported for identifiers, but the parser also supports formatted expressions in single quoted strings, which we could straightforwardly convert to a `CONCAT(...)` expression.