### PR TITLE
Isolate scope for projection terms

### DIFF
--- a/queryscript/src/compile/scope.rs
+++ b/queryscript/src/compile/scope.rs
@@ -42,7 +42,7 @@ impl Constrainable for FieldMatch {}
 pub struct SQLScope {
     parent: Option<Ref<SQLScope>>,
     relations: BTreeMap<Ident, (CRef<MType>, SourceLocation)>,
-    projection_terms: BTreeMap<Ident, CTypedSQL>,
+    pub projection_terms: BTreeMap<Ident, CTypedSQL>,
 }
 
 impl SQLScope {
@@ -221,12 +221,6 @@ impl SQLScope {
                 e.insert((type_, loc.clone()));
             }
         };
-        Ok(())
-    }
-
-    pub fn add_projection_term(&mut self, name: &Ident, sql: &CTypedSQL) -> Result<()> {
-        // Only insert it if it's not already part of a relation
-        self.projection_terms.insert(name.clone(), sql.clone());
         Ok(())
     }
 }


### PR DESCRIPTION
Before this change, we'd update the set of projection terms in the scope as we compile the query. However, now that compilation is more complex, we could end up in a state where we insert the projection term we're currently compiling _before_ fully compiling that term, and therefore deadlocking on `get_available_references()`.

This change reworks `compile_select_item()` to clone the scope for each projection term, so that it has a frozen set of (pre-existing) projection terms to compile against. It was a bit tricky to make this work well for loops, which I did by adding a per-loop-body state object that callers to `compile_foreach()` can create.

Although this change is quite difficult to verify, the deadlock reproduced on an incoming change, which I've verified no longer deadlocks with this change in place.