### PR TITLE
Fix EOF string printing bug

### DIFF
--- a/queryscript/src/ast/mod.rs
+++ b/queryscript/src/ast/mod.rs
@@ -69,7 +69,8 @@ impl SourceLocation {
                 r.start.line,
                 r.start.column,
                 r.end.column,
-                &lines[r.start.line as usize - 1..r.end.line as usize],
+                &lines
+                    [r.start.line as usize - 1..(std::cmp::min(r.end.line as usize, lines.len()))],
             ),
         };
 


### PR DESCRIPTION
If a file ends without a semicolon, the parser would crash trying to print an error.