### PR TITLE
Use DuckDB to load files and support remote (e.g. HTTP) files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -179,13 +179,8 @@ jobs:
       #          key:
       #            ${{ matrix.target }}-venv-${{ hashFiles('./qsutils/setup.py') }}-${{ github.run_id }}
 
-      - name: Copy test files
-        run: cp -r ./queryscript/tests/qs /tmp/
-
       - name: Start services
         run: /usr/bin/docker compose -f services/docker-compose.yml up -d
-        env:
-          QS_HTTP_TEST_DIR: /tmp/qs
 
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,26 +51,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 
-    services:
-      pg:
-        image: postgres:15
-        env:
-          POSTGRES_PASSWORD: example
-        ports:
-          - 5471:5432
-
-      clickhouse:
-        image: clickhouse/clickhouse-server:23
-        env:
-          CLICKHOUSE_PASSWORD: example
-        ports:
-          - 5472:9000
-      http:
-        image: halverneus/static-file-server
-        ports:
-          - 5473:8080
-        volumes:
-          - /home/runner/work/queryscript/queryscript/tests/qs:/web
+    #    services:
+    #      pg:
+    #        image: postgres:15
+    #        env:
+    #          POSTGRES_PASSWORD: example
+    #        ports:
+    #          - 5471:5432
+    #
+    #      clickhouse:
+    #        image: clickhouse/clickhouse-server:23
+    #        env:
+    #          CLICKHOUSE_PASSWORD: example
+    #        ports:
+    #          - 5472:9000
+    #      http:
+    #        image: halverneus/static-file-server
+    #        ports:
+    #          - 5473:8080
+    #        volumes:
+    #          - /home/runner/work/queryscript/queryscript/tests/qs:/web
 
     env:
       RA_TARGET: ${{ matrix.target }}
@@ -111,6 +111,9 @@ jobs:
           fetch-depth: ${{ env.FETCH_DEPTH }}
           submodules: true
           lfs: true
+
+      - name: Start services
+        run: /usr/bin/docker compose --network ${{ job.container.network }} -e ./services/docker-compose.yml
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           lfs: true
 
       - name: Start services
-        run: /usr/bin/docker compose --network ${{ job.container.network }} -e ./services/docker-compose.yml
+        run: /usr/bin/docker compose -f services/docker-compose.yml up -d
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -179,8 +179,13 @@ jobs:
       #          key:
       #            ${{ matrix.target }}-venv-${{ hashFiles('./qsutils/setup.py') }}-${{ github.run_id }}
 
+      - name: Copy test files
+        run: cp -r ./queryscript/tests/qs /tmp/
+
       - name: Start services
         run: /usr/bin/docker compose -f services/docker-compose.yml up -d
+        env:
+          QS_HTTP_TEST_DIR: /tmp/qs
 
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,9 +112,6 @@ jobs:
           submodules: true
           lfs: true
 
-      #      - name: Start services
-      #        run: /usr/bin/docker compose -f services/docker-compose.yml up -d
-
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -181,6 +178,9 @@ jobs:
       #            venv
       #          key:
       #            ${{ matrix.target }}-venv-${{ hashFiles('./qsutils/setup.py') }}-${{ github.run_id }}
+
+      - name: Start services
+        run: /usr/bin/docker compose -f services/docker-compose.yml up -d
 
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
         ports:
           - 5473:8080
         volumes:
-          - queryscript/tests/qs:/web
+          - /home/runner/work/queryscript/queryscript/tests/qs:/web
 
     env:
       RA_TARGET: ${{ matrix.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,12 @@ jobs:
           CLICKHOUSE_PASSWORD: example
         ports:
           - 5472:9000
+      http:
+        image: halverneus/static-file-server
+        ports:
+          - 5473:8080
+        volumes:
+          - queryscript/tests/qs:/web
 
     env:
       RA_TARGET: ${{ matrix.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,8 +112,8 @@ jobs:
           submodules: true
           lfs: true
 
-      - name: Start services
-        run: /usr/bin/docker compose -f services/docker-compose.yml up -d
+      #      - name: Start services
+      #        run: /usr/bin/docker compose -f services/docker-compose.yml up -d
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/queryscript/src/compile/sql.rs
+++ b/queryscript/src/compile/sql.rs
@@ -2008,7 +2008,6 @@ pub fn compile_sqlquery(
             let compiled_order_by =
                 compile_order_by(&compiler, &schema, &scope, loc, &query.order_by)?;
 
-            let loc = loc.clone();
             let compiler = compiler.clone();
             casync!({
                 let mut names = SQLNames::new();

--- a/queryscript/src/materialize/mod.rs
+++ b/queryscript/src/materialize/mod.rs
@@ -105,7 +105,7 @@ fn execute_create_view(
         }
 
         eprintln!("Creating view \"{}\"", name);
-        let sql_params = runtime::eval_params(&mut ctx, &params).await?;
+        let sql_params = runtime::eval_params_lazy(&mut ctx, &params).await?;
 
         let result = ctx
             .sql_engine(url.clone())

--- a/queryscript/src/runtime/functions.rs
+++ b/queryscript/src/runtime/functions.rs
@@ -1,31 +1,20 @@
-use arrow::{
-    datatypes::{DataType as ArrowDataType, Schema as ArrowSchema},
-    error::ArrowError,
-    record_batch::{RecordBatch as ArrowRecordBatch, RecordBatchReader},
-};
 use async_trait::async_trait;
 use futures::future::{BoxFuture, FutureExt};
 use sqlparser::ast as sqlast;
-use std::{any::Any, collections::HashMap, sync::Arc};
-use std::{
-    path::{Path as FilePath, PathBuf as FilePathBuf},
-    sync::Mutex,
-};
+use std::path::{Path as FilePath, PathBuf as FilePathBuf};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     compile::{
         schema::{self, Ident},
         sql::{select_limit_0, select_star_from},
     },
-    types::{
-        self, arrow::ArrowRecordBatchRelation, value::RecordBatch, Field, FnValue, LazyValue,
-        LazyValueClone, Relation, Type, TypesystemError, Value,
-    },
+    types::{self, Field, FnValue, LazyValue, LazyValueClone, Type, Value},
 };
 
 use super::{
     embedded_engine,
-    error::{fail, Result, RuntimeError},
+    error::{fail, Result},
     runtime, Context, LazySQLParam, SQLEngineType,
 };
 

--- a/queryscript/src/runtime/runtime.rs
+++ b/queryscript/src/runtime/runtime.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use futures::future::{BoxFuture, FutureExt};
 use std::collections::HashMap;
 

--- a/queryscript/src/runtime/runtime.rs
+++ b/queryscript/src/runtime/runtime.rs
@@ -1,15 +1,18 @@
+use async_trait::async_trait;
 use futures::future::{BoxFuture, FutureExt};
 use std::collections::HashMap;
 
 use crate::compile::schema;
 use crate::compile::sql::{create_table_as, select_star_from};
+use crate::types::LazyValue;
 use crate::{
     ast::Ident,
     types,
     types::{arrow::EMPTY_RELATION, Arc, Value},
 };
 
-use super::{context::Context, error::*, sql::SQLParam};
+use super::SQLParam;
+use super::{context::Context, error::*, sql::LazySQLParam};
 
 type TypeRef = schema::Ref<types::Type>;
 
@@ -46,28 +49,51 @@ where
     }
 }
 
-pub async fn eval_params<'a>(
+pub fn eval<'a>(
+    ctx: &'a mut Context,
+    typed_expr: &'a schema::TypedExpr<TypeRef>,
+) -> BoxFuture<'a, crate::runtime::Result<Value>> {
+    async move {
+        let mut lazy_value = eval_lazy(ctx, typed_expr).await?;
+        lazy_value.get().await
+    }
+    .boxed()
+}
+
+pub async fn eval_params_lazy<'a>(
     ctx: &'a mut Context,
     params: &'a schema::Params<TypeRef>,
-) -> Result<HashMap<Ident, SQLParam>> {
+) -> Result<HashMap<Ident, LazySQLParam>> {
     let mut param_values = HashMap::new();
     for (name, param) in params {
-        let value = eval(ctx, param).await?;
+        let value = eval_lazy(ctx, param).await?;
         param_values.insert(
             name.clone(),
-            SQLParam::new(name.clone(), value, &*param.type_.read()?),
+            LazySQLParam::new(name.clone(), value, &*param.type_.read()?),
         );
     }
 
     Ok(param_values)
 }
 
-pub fn eval<'a>(
+pub async fn resolve_params(
+    params: HashMap<Ident, LazySQLParam>,
+) -> Result<HashMap<Ident, SQLParam>> {
+    let mut resolved_params = HashMap::new();
+    for (name, param) in params.into_iter() {
+        let value = param.get().await?;
+        resolved_params.insert(name, value);
+    }
+
+    Ok(resolved_params)
+}
+
+pub fn eval_lazy<'a>(
     ctx: &'a mut Context,
     typed_expr: &'a schema::TypedExpr<TypeRef>,
-) -> BoxFuture<'a, crate::runtime::Result<crate::types::Value>> {
+) -> BoxFuture<'a, crate::runtime::Result<Box<dyn LazyValue>>> {
     async move {
-        match &*typed_expr.expr.as_ref() {
+        Ok(match &*typed_expr.expr.as_ref() {
             schema::Expr::Unknown => {
                 return Err(RuntimeError::new("unresolved extern"));
             }
@@ -83,32 +109,34 @@ pub fn eval<'a>(
                 return Err(RuntimeError::new("unresolved connection"));
             }
             schema::Expr::ContextRef(r) => match ctx.values.get(r) {
-                Some(v) => Ok(v.clone()), // Can we avoid this clone??
-                None => Err(RuntimeError::new(
-                    format!("No such context value {}", r).as_str(),
-                )),
+                Some(v) => v.clone().into(), // Can we avoid this clone??
+                None => {
+                    return Err(RuntimeError::new(
+                        format!("No such context value {}", r).as_str(),
+                    ))
+                }
             },
             schema::Expr::Fn(f) => {
                 use super::functions::*;
                 let body = match &f.body {
-                    schema::FnBody::Expr(e) => e.clone(),
+                    schema::FnBody::Expr(e) => e.clone().into(),
                     _ => {
                         return fail!(
                             "Non-expression function body should have been optimized away"
                         )
                     }
                 };
-                QSFn::new(typed_expr.type_.clone(), body)
+                QSFn::new(typed_expr.type_.clone(), body)?.into()
             }
             schema::Expr::NativeFn(name) => {
                 use super::functions::*;
                 match name.as_str() {
-                    "load" => Ok(Value::Fn(Arc::new(LoadFileFn::new(
-                        &*typed_expr.type_.read()?,
-                    )?))),
-                    "__native_identity" => Ok(Value::Fn(Arc::new(IdentityFn::new(
-                        &*typed_expr.type_.read()?,
-                    )?))),
+                    "load" => {
+                        Value::Fn(Arc::new(LoadFileFn::new(&*typed_expr.type_.read()?)?)).into()
+                    }
+                    "__native_identity" => {
+                        Value::Fn(Arc::new(IdentityFn::new(&*typed_expr.type_.read()?)?)).into()
+                    }
                     _ => return rt_unimplemented!("native function: {}", name),
                 }
             }
@@ -121,7 +149,7 @@ pub fn eval<'a>(
                 ..
             }) => {
                 if let (false, Some(value)) = (inlined, ctx.materializations.get(key)) {
-                    return Ok(value.clone());
+                    return Ok(value.clone().into());
                 }
 
                 if *inlined {
@@ -132,7 +160,7 @@ pub fn eval<'a>(
                         match expr.expr.as_ref() {
                             schema::Expr::SQL(sql, _) => {
                                 let query = create_table_as(table_name, sql.body.as_query()?, true);
-                                let sql_params = eval_params(ctx, &sql.names.params).await?;
+                                let sql_params = eval_params_lazy(ctx, &sql.names.params).await?;
                                 let _ = ctx
                                     .sql_engine(url.clone())
                                     .await?
@@ -169,15 +197,15 @@ pub fn eval<'a>(
                     // Don't stash the fact that we created the temporary table in the materialization index
                     // NOTE: For performance sake, we could cache something here (that we created the temp
                     // table), but for now we assume checking if the table exists is fast enough.
-                    Ok(EMPTY_RELATION.clone())
+                    EMPTY_RELATION.clone().into()
                 } else {
                     let result = eval(ctx, expr).await?;
 
-                    Ok(ctx
-                        .materializations
+                    ctx.materializations
                         .entry(key.clone())
                         .or_insert(result)
-                        .clone())
+                        .clone()
+                        .into()
                 }
             }
             schema::Expr::FnCall(schema::FnCallExpr {
@@ -189,7 +217,9 @@ pub fn eval<'a>(
                 new_ctx.folder = ctx_folder.clone();
                 let mut arg_values = Vec::new();
                 for arg in args.iter() {
-                    // Eval the arguments in the calling context
+                    // Eval the arguments in the calling context. Functions do not currently accept
+                    // lazy parameters, so evaluate them eagerly.
+                    // TODO: Change the function interface to accept lazy parameters
                     //
                     arg_values.push(eval(ctx, arg).await?);
                 }
@@ -198,11 +228,11 @@ pub fn eval<'a>(
                     _ => return fail!("Cannot call non-function"),
                 };
 
-                fn_val.execute(&mut new_ctx, arg_values).await
+                fn_val.execute(&mut new_ctx, arg_values).await?.into()
             }
             schema::Expr::SQL(e, url) => {
                 let schema::SQL { body, names } = e.as_ref();
-                let sql_params = eval_params(ctx, &names.params).await?;
+                let sql_params = eval_params_lazy(ctx, &names.params).await?;
                 let query = body.as_statement()?;
 
                 let engine = ctx.sql_engine(url.clone()).await?;
@@ -215,7 +245,7 @@ pub fn eval<'a>(
                 // - For expressions and queries, check that the RecordBatch's type matches the
                 //   expected type from the compiler.
                 let expected_type = typed_expr.type_.read()?;
-                match body {
+                let value = match body {
                     schema::SQLBody::Expr(_) => {
                         if rows.num_batches() != 1 {
                             return fail!("Expected an expression to have exactly one row");
@@ -233,7 +263,7 @@ pub fn eval<'a>(
                             rows = rows.try_cast(&target_schema)?;
                         }
                         let row = &rows.batch(0).records()[0];
-                        Ok(row.column(0).clone())
+                        row.column(0).clone()
                     }
                     schema::SQLBody::Query(_) | schema::SQLBody::Table(_) => {
                         // Validate that the schema matches the expected type. If not, we have a serious problem
@@ -265,11 +295,13 @@ pub fn eval<'a>(
                             }
                         }
 
-                        Ok(Value::Relation(rows))
+                        Value::Relation(rows)
                     }
-                }
+                };
+
+                value.into()
             }
-        }
+        })
     }
     .boxed()
 }

--- a/queryscript/src/types/error.rs
+++ b/queryscript/src/types/error.rs
@@ -16,6 +16,12 @@ pub enum TypesystemError {
         backtrace: Option<Backtrace>,
     },
 
+    #[snafu(context(false))]
+    RuntimeError {
+        source: Box<crate::runtime::RuntimeError>,
+        backtrace: Option<Backtrace>,
+    },
+
     #[snafu(display("Failed to parse as number: {}", val))]
     NumericParseError {
         val: String,

--- a/queryscript/tests/qs/faa/bad_schema.expected
+++ b/queryscript/tests/qs/faa/bad_schema.expected
@@ -10,8 +10,16 @@
     },
     "queries": [
         Err(
-            StringError {
-                what: "Parquet file \"tests/qs/faa/data/aircraft_models.parquet\" has a different schema than the target variable's type",
+            DuckDBError {
+                source: DuckDBFailure(
+                    Error {
+                        code: Unknown,
+                        extended_code: 1,
+                    },
+                    Some(
+                        "Binder Error: Table \"aircraft_models\" does not have a column named \"number_value\"\nLINE 1: SELECT \"MAX\"(\"aircraft_models\".\"number_value\") AS \"M...\n                     ^",
+                    ),
+                ),
                 backtrace: None,
             },
         ),

--- a/queryscript/tests/qs/jaffle/bad_schema.expected
+++ b/queryscript/tests/qs/jaffle/bad_schema.expected
@@ -10,9 +10,15 @@
     },
     "queries": [
         Err(
-            ArrowError {
-                source: CsvError(
-                    "incorrect number of fields for line 1, expected 1 got more than 1",
+            DuckDBError {
+                source: DuckDBFailure(
+                    Error {
+                        code: Unknown,
+                        extended_code: 1,
+                    },
+                    Some(
+                        "Binder Error: Table \"orders\" does not have a column named \"bool_value\"\nLINE 1: SELECT \"MAX\"(\"orders\".\"bool_value\") AS \"MAX(bool_val...\n                     ^",
+                    ),
                 ),
                 backtrace: None,
             },

--- a/queryscript/tests/qs/simple/error.expected
+++ b/queryscript/tests/qs/simple/error.expected
@@ -12,15 +12,15 @@
     ],
     "decls": {
         "let events": External<[{
+        	user_id UInt64,
         	description Utf8,
-        	ts Utf8,
-        	user_id Int64,
+        	ts Date32,
         }]>,
         "let users": External<[{
-        	active Boolean,
-        	id Int64,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
-        	org_id Int64,
+        	active Boolean,
         }]>,
     },
     "queries": [

--- a/queryscript/tests/qs/simple/fndef.expected
+++ b/queryscript/tests/qs/simple/fndef.expected
@@ -107,10 +107,10 @@
                 	foo ?field?,
                 },
                 rhs: {
-                	active Boolean,
-                	id Int64,
+                	id UInt64,
+                	org_id UInt64,
                 	name Utf8,
-                	org_id Int64,
+                	active Boolean,
                 },
                 backtrace: None,
             },
@@ -122,10 +122,10 @@
                     source: CoercionError {
                         types: [
                             {
-                            	active Boolean,
-                            	id Int64,
+                            	id UInt64,
+                            	org_id UInt64,
                             	name Utf8,
-                            	org_id Int64,
+                            	active Boolean,
                             },
                             Int64,
                         ],

--- a/queryscript/tests/qs/simple/functions.expected
+++ b/queryscript/tests/qs/simple/functions.expected
@@ -2,15 +2,15 @@
     "compile_errors": [],
     "decls": {
         "let events": External<[{
+        	user_id UInt64,
         	description Utf8,
-        	ts Utf8,
-        	user_id Int64,
+        	ts Date32,
         }]>,
         "let users": External<[{
-        	active Boolean,
-        	id Int64,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
-        	org_id Int64,
+        	active Boolean,
         }]>,
     },
     "queries": [
@@ -22,7 +22,7 @@
                             Field {
                                 name: "min(id)",
                                 type_: Atom(
-                                    Int64,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
@@ -40,7 +40,7 @@
                             Field {
                                 name: "max(id)",
                                 type_: Atom(
-                                    Int64,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
@@ -134,7 +134,7 @@
                                 name: "ARRAY_AGG(id)",
                                 type_: List(
                                     Atom(
-                                        Int64,
+                                        UInt64,
                                     ),
                                 ),
                                 nullable: true,

--- a/queryscript/tests/qs/simple/inference.expected
+++ b/queryscript/tests/qs/simple/inference.expected
@@ -2,15 +2,15 @@
     "compile_errors": [],
     "decls": {
         "let events": External<[{
+        	user_id UInt64,
         	description Utf8,
-        	ts Utf8,
-        	user_id Int64,
+        	ts Date32,
         }]>,
         "let users": External<[{
-        	active Boolean,
-        	id Int64,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
-        	org_id Int64,
+        	active Boolean,
         }]>,
     },
     "queries": [
@@ -20,16 +20,16 @@
                     Record(
                         [
                             Field {
-                                name: "active",
+                                name: "id",
                                 type_: Atom(
-                                    Boolean,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
                             Field {
-                                name: "id",
+                                name: "org_id",
                                 type_: Atom(
-                                    Int64,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
@@ -41,16 +41,16 @@
                                 nullable: true,
                             },
                             Field {
-                                name: "org_id",
+                                name: "active",
                                 type_: Atom(
-                                    Int64,
+                                    Boolean,
                                 ),
                                 nullable: true,
                             },
                         ],
                     ),
                 ),
-                value: "| active | id | name | org_id |\n|--------|----|------|--------|\n| true   | 1  | Foo  | 1      |\n| false  | 2  | Bar  | 1      |",
+                value: "| id | org_id | name | active |\n|----|--------|------|--------|\n| 1  | 1      | Foo  | true   |\n| 2  | 1      | Bar  | false  |",
             },
         ),
         Ok(
@@ -58,6 +58,13 @@
                 type_: List(
                     Record(
                         [
+                            Field {
+                                name: "user_id",
+                                type_: Atom(
+                                    UInt64,
+                                ),
+                                nullable: true,
+                            },
                             Field {
                                 name: "description",
                                 type_: Atom(
@@ -68,21 +75,14 @@
                             Field {
                                 name: "ts",
                                 type_: Atom(
-                                    Utf8,
-                                ),
-                                nullable: true,
-                            },
-                            Field {
-                                name: "user_id",
-                                type_: Atom(
-                                    Int64,
+                                    Date32,
                                 ),
                                 nullable: true,
                             },
                         ],
                     ),
                 ),
-                value: "| description | ts         | user_id |\n|-------------|------------|---------|\n| Loren Ipsum | 2020-01-01 | 1       |\n| Foo Bar     | 2020-01-02 | 1       |\n| Bing Baz    | 2020-01-03 | 2       |\n| Woo Hoo     | 2020-01-04 | 2       |",
+                value: "| user_id | description | ts         |\n|---------|-------------|------------|\n| 1       | Loren Ipsum | 2020-01-01 |\n| 1       | Foo Bar     | 2020-01-02 |\n| 2       | Bing Baz    | 2020-01-03 |\n| 2       | Woo Hoo     | 2020-01-04 |",
             },
         ),
     ],

--- a/queryscript/tests/qs/simple/join.expected
+++ b/queryscript/tests/qs/simple/join.expected
@@ -2,24 +2,24 @@
     "compile_errors": [],
     "decls": {
         "let events": External<[{
+        	user_id UInt64,
         	description Utf8,
-        	ts Utf8,
-        	user_id Int64,
+        	ts Date32,
         }]>,
         "let foo": [{
+        	user_id UInt64,
         	description Utf8,
-        	ts Utf8,
-        	user_id Int64,
-        	active Boolean,
-        	id Int64,
+        	ts Date32,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
-        	org_id Int64,
+        	active Boolean,
         }],
         "let users": External<[{
-        	active Boolean,
-        	id Int64,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
-        	org_id Int64,
+        	active Boolean,
         }]>,
     },
     "queries": [
@@ -31,7 +31,7 @@
                             Field {
                                 name: "user_id",
                                 type_: Atom(
-                                    Int64,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },

--- a/queryscript/tests/qs/simple/unsafe.expected
+++ b/queryscript/tests/qs/simple/unsafe.expected
@@ -133,14 +133,14 @@
                             Field {
                                 name: "id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
                             Field {
                                 name: "org_id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
@@ -161,7 +161,7 @@
                             Field {
                                 name: "user_id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
@@ -175,7 +175,7 @@
                             Field {
                                 name: "ts",
                                 type_: Atom(
-                                    Utf8,
+                                    Date32,
                                 ),
                                 nullable: true,
                             },
@@ -205,7 +205,7 @@
                             Field {
                                 name: "id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
@@ -223,14 +223,14 @@
                             Field {
                                 name: "id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
                             Field {
                                 name: "org_id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },

--- a/queryscript/tests/qs/simple/unsafe_complex_expr.expected
+++ b/queryscript/tests/qs/simple/unsafe_complex_expr.expected
@@ -2,23 +2,23 @@
     "compile_errors": [],
     "decls": {
         "let complex_expr": [{
-        	id Int64,
-        	org_id Int64,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
         	active Boolean,
         	id > 0 OR active Boolean,
-        	max_user Int64,
+        	max_user UInt64,
         }],
         "let events": External<[{
+        	user_id UInt64,
         	description Utf8,
-        	ts Utf8,
-        	user_id Int64,
+        	ts Date32,
         }]>,
         "let users": External<[{
-        	active Boolean,
-        	id Int64,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
-        	org_id Int64,
+        	active Boolean,
         }]>,
     },
     "queries": [
@@ -30,14 +30,14 @@
                             Field {
                                 name: "id",
                                 type_: Atom(
-                                    Int64,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
                             Field {
                                 name: "org_id",
                                 type_: Atom(
-                                    Int64,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
@@ -65,7 +65,7 @@
                             Field {
                                 name: "max_user",
                                 type_: Atom(
-                                    Int64,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },

--- a/queryscript/tests/qs/simple/unsafe_inference.expected
+++ b/queryscript/tests/qs/simple/unsafe_inference.expected
@@ -14,9 +14,9 @@
         	top Int64,
         }],
         "let events": External<[{
+        	user_id UInt64,
         	description Utf8,
-        	ts Utf8,
-        	user_id Int64,
+        	ts Date32,
         }]>,
         "let ordered_events": External<[{
         	rn Int64,
@@ -25,10 +25,10 @@
         	COUNT(*) Int64,
         }],
         "let users": External<[{
-        	active Boolean,
-        	id Int64,
+        	id UInt64,
+        	org_id UInt64,
         	name Utf8,
-        	org_id Int64,
+        	active Boolean,
         }]>,
         "type BogusEventRange": {
         	bottom Int32,

--- a/queryscript/tests/qs/simple/unsafe_paths.expected
+++ b/queryscript/tests/qs/simple/unsafe_paths.expected
@@ -18,14 +18,14 @@
                             Field {
                                 name: "id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },
                             Field {
                                 name: "org_id",
                                 type_: Atom(
-                                    Int32,
+                                    UInt64,
                                 ),
                                 nullable: true,
                             },

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       POSTGRES_PASSWORD: example
     ports:
       - 5471:5432
-    volumes:
-      - ./data/postgres:/var/lib/postgresql/data
+        #    volumes:
+        #      - ./data/postgres:/var/lib/postgresql/data
 
   clickhouse:
     image: clickhouse/clickhouse-server:23
@@ -19,10 +19,11 @@ services:
     ulimits:
       nofile:
         soft: 262144
-        hard: 262144
-    volumes:
-      - ./data/clickhouse:/var/lib/clickhouse/
-      - ./logs/clickhouse:/var/log/clickhouse-server/
+        hard:
+          262144
+          #    volumes:
+          #      - ./data/clickhouse:/var/lib/clickhouse/
+          #      - ./logs/clickhouse:/var/log/clickhouse-server/
 
   http:
     image: halverneus/static-file-server

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -29,4 +29,4 @@ services:
     ports:
       - 5473:8080
     volumes:
-      - ../queryscript/tests/qs:/web
+      - ${QS_HTTP_TEST_DIR:-../queryscript/tests/qs}:/web

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -23,3 +23,10 @@ services:
     volumes:
       - ./data/clickhouse:/var/lib/clickhouse/
       - ./logs/clickhouse:/var/log/clickhouse-server/
+
+  http:
+    image: halverneus/static-file-server
+    ports:
+      - 5473:8080
+    volumes:
+      - ../queryscript/tests/qs:/web


### PR DESCRIPTION
DuckDB has a lot of optimizations to process files efficiently, including files that are compressed, remote, on S3, etc. This change reworks how we load files to lean on this support instead of using Arrow directly.

The crux of the change is renaming `eval` to `eval_lazy` and by default returning a (potentially) lazily evaluated value. We take advantage of this new mechanic to lazily load files and return a parameter with the file name and format already parsed.  In DuckDB, we intercept this parameter and replace it with `read_csv_auto`, etc. In other engines, these files will naturally just evaluate into relation parameters.