### PR TITLE
Bundle extensions into DuckDB

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/qscl/sqlparser-rs.git
 [submodule "duckdb-rs"]
 	path = duckdb-rs
-	url = git@github.com:qscl/duckdb-rs.git
+	url = https://github.com/qscl/duckdb-rs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "sqlparser-rs"]
 	path = sqlparser-rs
 	url = https://github.com/qscl/sqlparser-rs.git
+[submodule "duckdb-rs"]
+	path = duckdb-rs
+	url = git@github.com:qscl/duckdb-rs.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,8 +949,6 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "duckdb"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed949102c3efdcfdef9d00542dcd34549dff102f6a61537bcfd78534dd027db"
 dependencies = [
  "arrow",
  "cast",
@@ -1510,11 +1508,12 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 [[package]]
 name = "libduckdb-sys"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418e710926ff3fca20f9f865ebb44dd8d1dbab74ddf0b5d93408bcc278d6d050"
 dependencies = [
+ "autocfg",
  "cc",
  "pkg-config",
+ "serde",
+ "serde_json",
  "vcpkg",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,15 +947,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "duckdb"
+name = "duckdb-queryscript"
 version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bf6a22e46bce0c904d0fc2a2a2b193fc881f5c47bce7eb5ee807fe078785d5"
 dependencies = [
  "arrow",
  "cast",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
- "libduckdb-sys",
+ "libduckdb-sys-queryscript",
  "memchr",
  "rust_decimal",
  "smallvec",
@@ -1506,8 +1508,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "libduckdb-sys"
+name = "libduckdb-sys-queryscript"
 version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1636827f42b3b5431e418170e0caf5b5e98faf854e75401572a5502e494a4d48"
 dependencies = [
  "autocfg",
  "cc",
@@ -2104,7 +2108,7 @@ dependencies = [
  "cxx",
  "cxx-build",
  "difference",
- "duckdb",
+ "duckdb-queryscript",
  "dyn-clone",
  "futures",
  "half",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +599,17 @@ checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
 dependencies = [
  "chrono",
  "parse-zoneinfo",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -632,7 +672,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -949,19 +989,31 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "duckdb-queryscript"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b839b72e33d6fe116cf71eb365ffe088d1de5849e0d92fe28830bc296aa9c692"
 dependencies = [
  "arrow",
+ "byteorder",
  "cast",
+ "chrono",
+ "csv",
+ "doc-comment",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
+ "lazy_static",
  "libduckdb-sys-queryscript",
  "memchr",
+ "r2d2",
+ "rand 0.8.5",
+ "regex",
  "rust_decimal",
+ "serde_json",
  "smallvec",
  "strum",
+ "tempdir",
+ "tempfile",
+ "unicase",
+ "url",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -1046,6 +1098,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "flatbuffers"
 version = "23.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1149,12 @@ name = "fs-err"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1438,6 +1508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "lexical-core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,16 +1585,28 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libduckdb-sys-queryscript"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba093b2125acf0cf50212aa9cb938e17e697add6719cf540c766c1eb8345cca"
+version = "0.7.3"
 dependencies = [
+ "arrow",
  "autocfg",
+ "bindgen",
  "cc",
+ "flate2",
  "pkg-config",
  "serde",
  "serde_json",
+ "tar",
  "vcpkg",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]
@@ -1662,6 +1750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1795,16 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1961,6 +2065,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2254,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,13 +2276,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2171,8 +2305,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2181,6 +2330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2230,6 +2388,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rend"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,7 +2442,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -2358,6 +2525,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -2446,6 +2622,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "simple_logger"
@@ -2633,6 +2815,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -3045,6 +3248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,6 +3471,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,9 +948,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "duckdb-queryscript"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bf6a22e46bce0c904d0fc2a2a2b193fc881f5c47bce7eb5ee807fe078785d5"
+checksum = "b839b72e33d6fe116cf71eb365ffe088d1de5849e0d92fe28830bc296aa9c692"
 dependencies = [
  "arrow",
  "cast",
@@ -1509,9 +1509,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libduckdb-sys-queryscript"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1636827f42b3b5431e418170e0caf5b5e98faf854e75401572a5502e494a4d48"
+checksum = "6ba093b2125acf0cf50212aa9cb938e17e697add6719cf540c766c1eb8345cca"
 dependencies = [
  "autocfg",
  "cc",

--- a/queryscript/Cargo.toml
+++ b/queryscript/Cargo.toml
@@ -95,7 +95,7 @@ url = "2.3.1"
 
 # -- ENGINES ---
 # DuckDB.
-duckdb = { version = "0.7.3", package = "duckdb-queryscript", features=["json", "httpfs", "parquet"] }
+duckdb = { path = "../duckdb-rs", version = "0.7.3", package = "duckdb-queryscript", features=["json", "httpfs", "parquet"] }
 # These are duckdb dependencies that we access directly
 hashlink = { version = "0.8" }
 

--- a/queryscript/Cargo.toml
+++ b/queryscript/Cargo.toml
@@ -95,7 +95,7 @@ url = "2.3.1"
 
 # -- ENGINES ---
 # DuckDB.
-duckdb = { version = "0.7.1" }
+duckdb = { version = "0.7.1", path = "../../duckdb-rs" }
 # These are duckdb dependencies that we access directly
 hashlink = { version = "0.8" }
 

--- a/queryscript/Cargo.toml
+++ b/queryscript/Cargo.toml
@@ -95,7 +95,7 @@ url = "2.3.1"
 
 # -- ENGINES ---
 # DuckDB.
-duckdb = { version = "0.7.1", package = "duckdb-queryscript" }
+duckdb = { version = "0.7.3", package = "duckdb-queryscript", features=["json", "httpfs", "parquet"] }
 # These are duckdb dependencies that we access directly
 hashlink = { version = "0.8" }
 

--- a/queryscript/Cargo.toml
+++ b/queryscript/Cargo.toml
@@ -95,7 +95,7 @@ url = "2.3.1"
 
 # -- ENGINES ---
 # DuckDB.
-duckdb = { version = "0.7.1", path = "../../duckdb-rs" }
+duckdb = { version = "0.7.1", package = "duckdb-queryscript" }
 # These are duckdb dependencies that we access directly
 hashlink = { version = "0.8" }
 

--- a/queryscript/src/runtime/duckdb/engine.rs
+++ b/queryscript/src/runtime/duckdb/engine.rs
@@ -421,20 +421,6 @@ impl ConnectionSingleton {
             None => Connection::open_in_memory(),
         }?;
 
-        // This allows us to use JSON functions (e.g. json_extract_string). It should only need to be run once
-        // while establishing a new connection. On my (Mac M1) laptop, it takes about 500ms.
-        //
-        // TODO: Ideally, we could statically bundle these into the distribution. As of now, DuckDB stashes these
-        // in the user's home directory and will downloaod them (from S3) if they're not present. Luckily, because
-        // we only instantiate one connection per unique DuckDB URL, this code only runs once (usually on startup).
-        conn.execute("INSTALL json", [])?;
-        conn.execute("LOAD json", [])?;
-
-        conn.execute("INSTALL parquet", [])?;
-        conn.execute("LOAD parquet", [])?;
-
-        conn.execute("INSTALL httpfs", [])?;
-        conn.execute("LOAD httpfs", [])?;
         Ok(Self(ExclusiveConnection::new(conn)))
     }
 


### PR DESCRIPTION
This change takes advantage of https://github.com/wangfenjin/duckdb-rs/pull/127 to directly bundle the relevant extensions into DuckDB. With this change, we can be sure that QueryScript will work across all platforms it compiles on, and startup times are much (~0.5-1s) faster.